### PR TITLE
Support Windows-style paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ exports.sync = function (x, opts) {
         || path.dirname(require.cache[__filename].parent.filename)
     ;
     
-    if (x.match(/^(?:\.\.?\/|\/)/)) {
+    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?\\)/)) {
         var m = loadAsFileSync(path.resolve(y, x))
             || loadAsDirectorySync(path.resolve(y, x));
         if (m) return m;


### PR DESCRIPTION
Similar to node-commondir, I encountered some trouble getting browserify to work on Windows, and patched this in the process. Unfortunately no tests for this change because path.resolve only works on Windows in node >= 0.5.X and I'm not willing to break the tests for 0.4.X.
