### PR TITLE
Fix resolving of modules found under a parent directory path in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ exports.sync = function (x, opts) {
     }
     
     function nodeModulesPathsSync (start) {
-        var parts = start.split(/\/+/);
+        var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
+        var parts = start.split(splitRe);
         
         var dirs = [];
         for (var i = parts.length - 1; i >= 0; i--) {


### PR DESCRIPTION
The regular expression used to split paths only worked on UNIX, causing module lookups within parent directories to fail. Fixed by pulling in appropriate logic from node/module

https://github.com/joyent/node/blob/master/lib/module.js#L214
