### PR TITLE
Prioritize parent node_module tree in nodeModulesPathsSync before fallback options.paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,6 @@ exports.sync = function (x, opts) {
             }
             dirs.push(dir);
         }
-        return opts.paths.concat(dirs);
+        return dirs.concat(opts.paths);
     }
 };


### PR DESCRIPTION
Hi James. According to http://nodejs.org/docs/latest/api/all.html#all_loading_from_the_global_folders, 
`If the NODE_PATH environment variable is set to a colon-delimited list of absolute paths, then node will search those paths for modules if they are not found elsewhere.`

Yet the implementation in `index.js` of the pertinent function, `nodeModulesPathsSync`, concatenated the list of node_module path combinations to the end of the NODE_PATH isomorphic options.dirs: this seems backwards, no?
