### PR TITLE
pkg.main can contain a directory instead of a file

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ exports.sync = function (x, opts) {
                 if (pkg.main) {
                     var m = loadAsFileSync(path.resolve(x, pkg.main));
                     if (m) return m;
+                    var n = loadAsDirectorySync(path.resolve(x, pkg.main));
+                    if (n) return n;
                 }
             }
             catch (err) {}


### PR DESCRIPTION
[pg](https://github.com/brianc/node-postgres/) for example has a directory specified in [pkg.main](https://github.com/brianc/node-postgres/blob/master/package.json#L11).
