### PR TITLE
resolve '../baz' correct

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ exports.sync = function (x, opts) {
         var m = loadAsFileSync(path.resolve(y, x))
             || loadAsDirectorySync(path.resolve(y, x));
         if (m) return m;
+    } else {
+        var n = loadNodeModulesSync(x, y);
+        if (n) return n;
     }
-    
-    var n = loadNodeModulesSync(x, y);
-    if (n) return n;
     
     throw new Error("Cannot find module '" + x + "'");
     

--- a/test/mock.js
+++ b/test/mock.js
@@ -2,7 +2,7 @@ var test = require('tap').test;
 var resolve = require('../');
 
 test('mock', function (t) {
-    t.plan(3);
+    t.plan(4);
     
     var files = {
         '/foo/bar/baz.js' : 'beep'
@@ -32,6 +32,10 @@ test('mock', function (t) {
     
     t.throws(function () {
         resolve.sync('baz', opts('/foo/bar'));
+    });
+
+    t.throws(function () {
+        resolve.sync('../baz', opts('/foo/bar'));
     });
 });
 


### PR DESCRIPTION
Makes it so that '../baz' doesn't resolve to ./baz.js
