### PR TITLE
Fix type error when `main` field points to a dir

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -51,7 +51,7 @@ module.exports = function resolve (x, opts, cb) {
         }
       
         (function load (exts) {
-            if (exts.length === 0) return cb(null, undefined);
+            if (exts.length === 0) return cb(null, undefined, pkg);
             var file = x + exts[0];
             
             isFile(file, function (err, ex) {


### PR DESCRIPTION
In some npm packages (e.g., validator, superagent),  the `main` filed in package.json  file points to a dir (e.g, './lib'). When trying to resolve these packages, node-resolve will throw `TypeError: Cannot read property 'main' of undefined` because `loadAsFile` did not pass the `pkg` argument when falling through.
