### PR TITLE
Passing error message when main file from package.json is not found

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -51,9 +51,9 @@ module.exports = function resolve (x, opts, cb) {
         }
       
         (function load (exts) {
-            if (exts.length === 0) return cb(null, undefined);
+            if (exts.length === 0) return cb(null, undefined, pkg);
             var file = x + exts[0];
-            
+
             isFile(file, function (err, ex) {
                 if (err) cb(err)
                 else if (ex) cb(null, file, pkg)
@@ -89,10 +89,21 @@ module.exports = function resolve (x, opts, cb) {
                         if (err) return cb(err);
                         if (m) return cb(null, m, pkg);
                         var dir = path.resolve(x, pkg.main);
+
                         loadAsDirectory(dir, pkg, function (err, n, pkg) {
                             if (err) return cb(err);
                             if (n) return cb(null, n, pkg);
-                            loadAsFile(path.join(x, '/index'), pkg, cb);
+
+                            var isMainFilePresent = function(err, m, pkg){
+                                if (err) return cb(err);
+                                if (!m) {
+                                    return cb(new Error("Failed to resolve package.json's main file " + dir)); }
+                                else {
+                                    return cb(err, m, pkg);
+                                }
+                            };
+
+                            loadAsFile(path.join(x, '/index'), pkg, isMainFilePresent);
                         });
                     });
                     return;


### PR DESCRIPTION
I've met the same problem as was described in this issue https://github.com/substack/node-resolve/issues/22. I investigated a little and found that this error occurs when, due to some reasons, package is missing the main file.(was not compiled properly after install or some raise conditions e.t.c.)

This fix returns appropriate error message that informs about that. I think this is more expected behaviour than just failure with no additional info.
