### PR TITLE
Fix default basedir calculation

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -2,6 +2,15 @@ var core = require('./core');
 var fs = require('fs');
 var path = require('path');
 
+function getCaller() {
+  // see https://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+  var origPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = function (_, stack) { return stack };
+  var stack = (new Error()).stack;
+  Error.prepareStackTrace = origPrepareStackTrace;
+  return stack[2];
+}
+
 module.exports = function resolve (x, opts, cb) {
     if (core[x]) return cb(null, x);
     
@@ -22,7 +31,7 @@ module.exports = function resolve (x, opts, cb) {
     
     var extensions = opts.extensions || [ '.js' ];
     var y = opts.basedir
-        || path.dirname(require.cache[__filename].parent.filename)
+        || path.dirname(getCaller().getFileName())
     ;
     
     opts.paths = opts.paths || [];

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -252,3 +252,19 @@ test('incorrect main', function (t) {
         t.equal(res, dir + '/index.js');
     });
 });
+
+test('without basedir', function (t) {
+    t.plan(1);
+
+    var dir = __dirname + '/resolver/without_basedir';
+    var tester = require(dir + '/main.js');
+
+    tester(t, function (err, res, pkg){
+        if (err) {
+	  t.fail(err);
+	} else {
+          t.equal(res, dir + '/node_modules/mymodule.js');
+	}
+    });
+});
+

--- a/test/resolver/without_basedir/main.js
+++ b/test/resolver/without_basedir/main.js
@@ -1,0 +1,6 @@
+resolve = require('../../../');
+
+module.exports = function(t, cb) {
+  resolve('mymodule', null, cb);
+}
+

--- a/test/resolver/without_basedir/node_modules/mymodule.js
+++ b/test/resolver/without_basedir/node_modules/mymodule.js
@@ -1,0 +1,1 @@
+module.exports = "The tools we use have a profound (and devious!) influence on our thinking habits, and, therefore, on our thinking abilities.- E. Dijkstra"


### PR DESCRIPTION
Using the `require.cache` to identify which module is calling us is not reliable. It will always tell you what the _first_ module to require us was, not the module that's currently calling.

This change uses the V8 stack trace API to identify the real current caller.
