### PR TITLE
modules folder name is configurable

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -23,6 +23,7 @@ module.exports = function resolve (x, opts, cb) {
     
     var extensions = opts.extensions || [ '.js' ];
     var y = opts.basedir || path.dirname(caller());
+    var modules = opts.modules || 'node_modules';
     
     opts.paths = opts.paths || [];
     
@@ -127,10 +128,10 @@ module.exports = function resolve (x, opts, cb) {
         
         var dirs = [];
         for (var i = parts.length - 1; i >= 0; i--) {
-            if (parts[i] === 'node_modules') continue;
+            if (parts[i] === modules) continue;
             var dir = path.join(
                 path.join.apply(path, parts.slice(0, i + 1)),
-                'node_modules'
+                modules
             );
             if (!parts[0].match(/([A-Za-z]:)/)) {
                 dir = '/' + dir;    

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -16,6 +16,7 @@ module.exports = function (x, opts) {
     
     var extensions = opts.extensions || [ '.js' ];
     var y = opts.basedir || path.dirname(caller());
+    var modules = opts.modules || 'node_modules';
 
     opts.paths = opts.paths || [];
 
@@ -83,10 +84,10 @@ module.exports = function (x, opts) {
         
         var dirs = [];
         for (var i = parts.length - 1; i >= 0; i--) {
-            if (parts[i] === 'node_modules') continue;
+            if (parts[i] === modules) continue;
             var dir = path.join(
                 path.join.apply(path, parts.slice(0, i + 1)),
-                'node_modules'
+                modules
             );
             if (!parts[0].match(/([A-Za-z]:)/)) {
                 dir = '/' + dir;    


### PR DESCRIPTION
Make the name of the modules folder configurable to something other than `node_modules` by setting `opts.modules`.
This allows you to use the node resolve algorithm to resolve all kinds of crazy stuff like config files, templates etc.

``` js
var resolve = require('resolve');
// use config instead of node_modules and find the nearest config file
var configPath = resolve('test', {
    modules: 'config',
    extensions: ['json']
});
// use views for our templates
var templatePath = resolve('my-template', {
    modules: 'views',
    extensions: ['html']
});
```
