### PR TITLE
Provide context when resolution fails

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -35,14 +35,14 @@ module.exports = function resolve (x, opts, cb) {
             else loadAsDirectory(path.resolve(y, x), function (err, d, pkg) {
                 if (err) cb(err)
                 else if (d) cb(null, d, pkg)
-                else cb(new Error("Cannot find module '" + x + "'"))
+                else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
             })
         });
     }
     else loadNodeModules(x, y, function (err, n, pkg) {
         if (err) cb(err)
         else if (n) cb(null, n, pkg)
-        else cb(new Error("Cannot find module '" + x + "'"))
+        else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
     });
     
     function loadAsFile (x, pkg, cb) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -29,7 +29,7 @@ module.exports = function (x, opts) {
         if (n) return n;
     }
     
-    throw new Error("Cannot find module '" + x + "'");
+    throw new Error("Cannot find module '" + x + "' from '" + y + "'");
     
     function loadAsFileSync (x) {
         if (isFile(x)) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -33,11 +33,11 @@ test('mock', function (t) {
     });
     
     resolve('baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module 'baz'");
+        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar'");
     });
     
     resolve('../baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module '../baz'");
+        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar'");
     });
 });
 
@@ -74,11 +74,11 @@ test('mock from package', function (t) {
     });
     
     resolve('baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module 'baz'");
+        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar'");
     });
     
     resolve('../baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module '../baz'");
+        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar'");
     });
 });
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var test = require('tap').test;
 var resolve = require('../');
 
@@ -30,7 +31,7 @@ test('async foo', function (t) {
     });
     
     resolve('foo', { basedir : dir }, function (err) {
-        t.equal(err.message, "Cannot find module 'foo'");
+        t.equal(err.message, "Cannot find module 'foo' from '" + path.resolve(dir) + "'");
     });
 });
 
@@ -190,7 +191,7 @@ test('cup', function (t) {
     
     resolve('./cup', { basedir : dir, extensions : [ '.js' ] },
     function (err, res) {
-        t.equal(err.message, "Cannot find module './cup'");
+        t.equal(err.message, "Cannot find module './cup' from '" + path.resolve(dir) + "'");
     });
 });
 
@@ -233,11 +234,11 @@ test('other path', function (t) {
     });
     
     resolve('root', { basedir : dir, }, function (err, res) {
-        t.equal(err.message, "Cannot find module 'root'");
+        t.equal(err.message, "Cannot find module 'root' from '" + path.resolve(dir) + "'");
     });
     
     resolve('zzz', { basedir : dir, paths: [otherDir] }, function (err, res) {
-        t.equal(err.message, "Cannot find module 'zzz'");
+        t.equal(err.message, "Cannot find module 'zzz' from '" + path.resolve(dir) + "'");
     });
 });
 


### PR DESCRIPTION
When a build failures on browserify, it just complains that it can't find a certain module, it doesn't say where it's trying to find it from.

This doesn't actually identify the source file, but at least tells you what directory you should be searching for problems in.

For example:

```
Error: Cannot find module 'tap' from '/Users/jlfwong/code/node-resolve/example'
```
