### PR TITLE
faulty basedir does not always error properly in windows

### DIFF
--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -21,5 +21,8 @@ module.exports = function (start, opts) {
         );
         dirs.push(prefix + dir);
     }
+    if(process.platform === 'win32'){
+        dirs[dirs.length-1] = dirs[dirs.length-1].replace(":", ":\\");
+    }
     return dirs.concat(opts.paths);
 }

--- a/test/faulty_basedir.js
+++ b/test/faulty_basedir.js
@@ -1,0 +1,14 @@
+var path = require('path');
+var test = require('tap').test;
+var resolve = require('../');
+
+test('faulty basedir must produce error in windows', function (t) {
+    t.plan(1);
+
+    var resolverDir = 'C:\\a\\b\\c\\d';
+
+    resolve('tap/lib/main.js', { basedir : resolverDir }, function (err, res, pkg) {
+        t.equal(true, !!err);
+    });
+
+});


### PR DESCRIPTION
faulty basedir does not always produce error properly in windows, because when the dirs are sliced down the final path has an improper prefix resulting in paths like "C:node_modules\module\transform.js" (notice missing slash), which, at least in my case, causes it to attempt to resolve "node_modules..." relative to the cwd.  this sometimes will actually succeed causing havoc down the line instead of erroring as it should.  see added test for more clarity
