### PR TITLE
Fixed the case when main is specified as "." or "./" causing the resolve...

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -85,6 +85,9 @@ module.exports = function resolve (x, opts, cb) {
                 }
                 
                 if (pkg.main) {
+                    if (pkg.main === '.' || pkg.main === './'){
+                        pkg.main = 'index'
+                    }
                     loadAsFile(path.resolve(x, pkg.main), pkg, function (err, m, pkg) {
                         if (err) return cb(err);
                         if (m) return cb(null, m, pkg);


### PR DESCRIPTION
... to infinite loop as documented at https://github.com/substack/node-browserify/issues/732.
