### PR TITLE
node-modules-paths: absolutize the `start` path

### DIFF
--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -12,6 +12,11 @@ module.exports = function (start, opts) {
         prefix = '\\\\';
     }
     var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\/+/;
+
+    // ensure that `start` is an absolute path at this point,
+    // resolving againt the process' current working directory
+    start = path.resolve(start);
+
     var parts = start.split(splitRe);
 
     var dirs = [];

--- a/test/node_path.js
+++ b/test/node_path.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var test = require('tap').test;
 var resolve = require('../');
 
@@ -32,5 +33,16 @@ test('$NODE_PATH', function (t) {
         basedir: __dirname,
     }, function (err, res) {
         t.equal(res, __dirname + '/node_path/x/ccc/index.js');
+    });
+
+    // ensure that relative paths still resolve against the
+    // regular `node_modules` correctly
+    resolve('tap', {
+        paths: [
+            'node_path',
+        ],
+        basedir: 'node_path/x',
+    }, function (err, res) {
+        t.equal(res, path.resolve(__dirname, '..', 'node_modules/tap/lib/main.js'));
     });
 });


### PR DESCRIPTION
This ensures that a properly built full array of files paths
with the `modulesDir` at the end will be returned, so that
dependencies are properly resolved even with a relative path.
