### PR TITLE
Match Windows directories with forward slashes

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -25,7 +25,7 @@ module.exports = function resolve (x, opts, cb) {
     
     opts.paths = opts.paths || [];
     
-    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?\\)/)) {
+    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?(\\|\/))/)) {
         loadAsFile(path.resolve(y, x), function (err, m, pkg) {
             if (err) cb(err)
             else if (m) cb(null, m, pkg)

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -18,7 +18,7 @@ module.exports = function (x, opts) {
 
     opts.paths = opts.paths || [];
 
-    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?\\)/)) {
+    if (x.match(/^(?:\.\.?\/|\/|([A-Za-z]:)?(\\|\/))/)) {
         var m = loadAsFileSync(path.resolve(y, x))
             || loadAsDirectorySync(path.resolve(y, x));
         if (m) return m;


### PR DESCRIPTION
I had an edge case with absolute paths on Windows. After several Browserify transforms, I was ultimately requiring a filepath like,

```
D:/some/project/directory/file.js
```

Admittedly that is a strange looking path, because it's using forward slashes with a Windows drive letter. However, I cross-referenced `require.resolve` and it handled it correctly, so I thought I would track down the discrepancy in `node-resolve`. The path was not matching the regex used to differentiate files from modules. Adding a small _or_ to the regex seems to solve this for me.
