### PR TITLE
Update main README--change word order for clarity

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -65,8 +65,7 @@ at the "main" field
 * opts.paths - require.paths array to use if nothing is found on the normal
 node_modules recursive walk (probably don't use this)
 
-* opts.moduleDirectory - directory (or directories) to recursively look for modules in. default:
-`"node_modules"`
+* opts.moduleDirectory - directory (or directories) in which to recursively look for modules. default: `"node_modules"`
 
 default `opts` values:
 
@@ -108,8 +107,7 @@ at the "main" field
 * opts.paths - require.paths array to use if nothing is found on the normal
 node_modules recursive walk (probably don't use this)
 
-* opts.moduleDirectory - directory (or directories) to recursively look for modules in. default:
-`"node_modules"`
+* opts.moduleDirectory - directory (or directories) in which to recursively look for modules. default: `"node_modules"`
 
 default `opts` values:
 


### PR DESCRIPTION
Same change occurs in two places: line 68 and line 110.  Just for better readability.

before:
![screen shot 2014-10-12 at 2 07 01 am](https://cloud.githubusercontent.com/assets/4251807/4605613/3dfd591c-51ef-11e4-9eca-8ede82a4bd88.png)

after:
![screen shot 2014-10-12 at 2 07 28 am](https://cloud.githubusercontent.com/assets/4251807/4605616/5647131e-51ef-11e4-88c9-427458f6e060.png)
