### PR TITLE
Report parent module filename in "Error: Cannot find module" output

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -27,7 +27,8 @@ module.exports = function resolve (x, opts, cb) {
     
     var extensions = opts.extensions || [ '.js' ];
     var y = opts.basedir || path.dirname(caller());
-    
+    var parent = opts.filename || y;
+
     opts.paths = opts.paths || [];
     
     if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[\\\/])/.test(x)) {
@@ -39,7 +40,7 @@ module.exports = function resolve (x, opts, cb) {
             else loadAsDirectory(path.resolve(y, x), function (err, d, pkg) {
                 if (err) cb(err)
                 else if (d) cb(null, d, pkg)
-                else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
+                else cb(new Error("Cannot find module '" + x + "' from '" + parent + "'"))
             })
         });
     }
@@ -47,7 +48,7 @@ module.exports = function resolve (x, opts, cb) {
         if (err) cb(err)
         else if (n) cb(null, n, pkg)
         else if (core[x]) return cb(null, x);
-        else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
+        else cb(new Error("Cannot find module '" + x + "' from '" + parent + "'"))
     });
     
     function loadAsFile (x, pkg, cb) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,6 +15,7 @@ module.exports = function (x, opts) {
     
     var extensions = opts.extensions || [ '.js' ];
     var y = opts.basedir || path.dirname(caller());
+    var parent = opts.filename || y;
 
     opts.paths = opts.paths || [];
 
@@ -29,9 +30,9 @@ module.exports = function (x, opts) {
     }
     
     if (core[x]) return x;
-    
-    throw new Error("Cannot find module '" + x + "' from '" + y + "'");
-    
+
+    throw new Error("Cannot find module '" + x + "' from '" + parent + "'");
+
     function loadAsFileSync (x) {
         if (isFile(x)) {
             return x;

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -180,7 +180,7 @@ test('normalize', function (t) {
 });
 
 test('cup', function (t) {
-    t.plan(3);
+    t.plan(4);
     var dir = __dirname + '/resolver';
     
     resolve('./cup', { basedir : dir, extensions : [ '.js', '.coffee' ] },
@@ -197,6 +197,12 @@ test('cup', function (t) {
     resolve('./cup', { basedir : dir, extensions : [ '.js' ] },
     function (err, res) {
         t.equal(err.message, "Cannot find module './cup' from '" + path.resolve(dir) + "'");
+    });
+
+    // Test that filename is reported as the "from" value when passed.
+    resolve('./cup', { basedir : dir, extensions : [ '.js' ], filename : path.join(dir, 'cupboard.js') },
+    function (err, res) {
+        t.equal(err.message, "Cannot find module './cup' from '" + path.join(dir, 'cupboard.js') + "'");
     });
 });
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -3,7 +3,7 @@ var test = require('tap').test;
 var resolve = require('../');
 
 test('async foo', function (t) {
-    t.plan(9);
+    t.plan(10);
     var dir = __dirname + '/resolver';
     
     resolve('./foo', { basedir : dir }, function (err, res, pkg) {
@@ -32,6 +32,11 @@ test('async foo', function (t) {
     
     resolve('foo', { basedir : dir }, function (err) {
         t.equal(err.message, "Cannot find module 'foo' from '" + path.resolve(dir) + "'");
+    });
+
+    // Test that filename is reported as the "from" value when passed.
+    resolve('foo', { basedir : dir, filename : path.join(dir, 'baz.js') }, function (err) {
+        t.equal(err.message, "Cannot find module 'foo' from '" + path.join(dir, 'baz.js') + "'");
     });
 });
 

--- a/test/resolver_sync.js
+++ b/test/resolver_sync.js
@@ -1,5 +1,6 @@
 var test = require('tap').test;
 var resolve = require('../');
+var path = require('path');
 
 test('foo', function (t) {
     var dir = __dirname + '/resolver';
@@ -17,7 +18,19 @@ test('foo', function (t) {
     t.throws(function () {
         resolve.sync('foo', { basedir : dir });
     });
-    
+
+    // Test that filename is reported as the "from" value when passed.
+    t.throws(
+        function () {
+            resolve.sync('foo', { basedir : dir, filename : path.join(dir, 'bar.js') });
+        },
+        {
+            name : 'Error',
+            message : "Cannot find module 'foo' from '" +
+                path.join(dir, 'bar.js') + "'"
+        }
+    );
+
     t.end();
 });
 


### PR DESCRIPTION
Fix #60.

There were several tests in `test/resolver.js` for the `Cannot find module` error and I added new tests at a couple of those locations. It didn't seem like there'd be any additional value to add new tests at the other locations -- do you agree?

The next step toward exposing this in browserify will be getting browser-resolve to bump the resolve version.
