### PR TITLE
Fix error when some package.json have `browser` field as an object.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -144,7 +144,7 @@ module.exports = function resolve (x, opts, cb) {
                     pkg = opts.packageFilter(pkg, pkgfile);
                 }
                 
-                if (pkg.main) {
+                if (pkg.main && typeof pkg.main === 'string') {
                     if (pkg.main === '.' || pkg.main === './'){
                         pkg.main = 'index'
                     }


### PR DESCRIPTION
Typically `methods` module dependent by `express`.
