### PR TITLE
Migrate splitRe to native function

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
-var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
 
 module.exports = function resolve (x, opts, cb) {
     if (typeof opts === 'function') {

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -17,9 +17,7 @@ module.exports = function (start, opts) {
         prefix = '\\\\';
     }
 
-    var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\/+/;
-
-    var parts = start.split(splitRe);
+    var parts = start.split(path.sep);
 
     var dirs = [];
     for (var i = parts.length - 1; i >= 0; i--) {


### PR DESCRIPTION
- Migrate [splitRe](https://github.com/substack/node-resolve/blob/master/lib/node-modules-paths.js#L20) to native function [path.sep](https://nodejs.org/api/path.html#path_path_sep)
- Remove unused [variable](https://github.com/substack/node-resolve/blob/master/lib/async.js#L6)
- Update to two last versions of Node in .travis.yml
