### PR TITLE
Add simple CLI utility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,12 @@
     },
     "overrides": [
         {
+            "files": "bin/**",
+            "rules": {
+                "no-process-exit": "off",
+            },
+        },
+        {
             "files": "example/**",
             "rules": {
                 "no-console": 0,

--- a/bin/resolve
+++ b/bin/resolve
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+if (
+    !process.argv
+    || process.argv.length < 2
+    || (process.argv[1] !== __filename && fs.statSync(process.argv[1]).ino !== fs.statSync(__filename).ino)
+    || (process.env._ && path.resolve(process.env._) !== __filename)
+) {
+    console.error('Error: `resolve` must be run directly as an executable');
+    process.exit(1);
+}
+
+var supportsPreserveSymlinkFlag = require('supports-preserve-symlinks-flag');
+
+var preserveSymlinks = false;
+for (var i = 2; i < process.argv.length; i += 1) {
+    if (process.argv[i].slice(0, 2) === '--') {
+        if (supportsPreserveSymlinkFlag && process.argv[i] === '--preserve-symlinks') {
+            preserveSymlinks = true;
+        } else if (process.argv[i].length > 2) {
+            console.error('Unknown argument ' + process.argv[i].replace(/[=].*$/, ''));
+            process.exit(2);
+        }
+        process.argv.splice(i, 1);
+        i -= 1;
+        if (process.argv[i] === '--') { break; } // eslint-disable-line no-restricted-syntax
+    }
+}
+
+if (process.argv.length < 3) {
+    console.error('Error: `resolve` expects a specifier');
+    process.exit(2);
+}
+
+var resolve = require('../');
+
+var result = resolve.sync(process.argv[2], {
+    basedir: process.cwd(),
+    preserveSymlinks: preserveSymlinks
+});
+
+console.log(result);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 		"type": "git",
 		"url": "git://github.com/browserify/resolve.git"
 	},
+	"bin": {
+		"resolve": "./bin/resolve"
+	},
 	"main": "index.js",
 	"exports": {
 		".": [
@@ -38,7 +41,7 @@
 		"prepublishOnly": "safe-publish-latest",
 		"prepublish": "not-in-publish || npm run prepublishOnly",
 		"prelint": "eclint check $(git ls-files | xargs find 2> /dev/null | grep -vE 'node_modules|\\.git')",
-		"lint": "eslint --ext=js,mjs --no-eslintrc -c .eslintrc .",
+		"lint": "eslint --ext=js,mjs --no-eslintrc -c .eslintrc . 'bin/**'",
 		"pretests-only": "cd ./test/resolver/nested_symlinks && node mylib/sync && node mylib/async",
 		"tests-only": "tape test/*.js",
 		"pretest": "npm run lint",
@@ -69,6 +72,7 @@
 	},
 	"dependencies": {
 		"is-core-module": "^2.8.0",
-		"path-parse": "^1.0.7"
+		"path-parse": "^1.0.7",
+		"supports-preserve-symlinks-flag": "^1.0.0"
 	}
 }


### PR DESCRIPTION
Very simple addition. Allows `resolve` to be installed globally or to be used as part of an npm script.

**Example**

I want to add `eslint` and a [TAP reporter](https://github.com/sindresorhus/eslint-tap) to my project. My `package.json`:

_**Before**_

``` json
{
    "devDependencies": {
        "eslint": "*",
        "eslint-tap": "*"
    },
    "scripts": {
        "test": "eslint . --format node_modules/eslint-tap/tap.js"
    }
}
```

Bad. No guarantee that formatter will exist at that path.

_**After**_

``` json
{
    "devDependencies": {
        "resolve": "*",
        "eslint": "*",
        "eslint-tap": "*"
    },
    "scripts": {
        "test": "eslint . --format $(resolve eslint-tap/tap)"
    }
}
```

Good. Path is not hard coded.
