### PR TITLE
Add support for pathfilter in resolve.sync

### DIFF
--- a/test/pathfilter_sync.js
+++ b/test/pathfilter_sync.js
@@ -1,0 +1,23 @@
+var test = require('tape');
+var resolve = require('../');
+
+test('synchronous pathfilter', function (t) {
+    var res;
+    var resolverDir = __dirname + '/pathfilter/deep_ref';
+    var pathFilter = function (pkg, x, remainder) {
+        t.equal(pkg.version, '1.2.3');
+        t.equal(x, resolverDir + '/node_modules/deep/ref');
+        t.equal(remainder, 'ref');
+        return 'alt';
+    };
+
+    res = resolve.sync('deep/ref', { basedir: resolverDir });
+    t.equal(res, resolverDir + '/node_modules/deep/ref.js');
+
+    res = resolve.sync('deep/deeper/ref', { basedir: resolverDir });
+    t.equal(res, resolverDir + '/node_modules/deep/deeper/ref.js');
+
+    res = resolve.sync('deep/ref', { basedir: resolverDir, pathFilter: pathFilter });
+    t.equal(res, resolverDir + '/node_modules/deep/alt.js');
+    t.end();
+});


### PR DESCRIPTION
@substack I want to use `node-browser-resolve` in a synchronous way, it requires the `pathfilter` option though, so I've added it to the synchronous resolve function.
