### PR TITLE
Update to use default `require.extensions`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -31,7 +31,7 @@ module.exports = function resolve(x, options, callback) {
     var isFile = opts.isFile || defaultIsFile;
     var readFile = opts.readFile || fs.readFile;
 
-    var extensions = opts.extensions || ['.js'];
+    var extensions = opts.extensions || Object.keys(require.extensions);
     var basedir = opts.basedir || path.dirname(caller());
 
     opts.paths = opts.paths || [];

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -22,7 +22,7 @@ module.exports = function (x, options) {
     var isFile = opts.isFile || defaultIsFile;
     var readFileSync = opts.readFileSync || fs.readFileSync;
 
-    var extensions = opts.extensions || ['.js'];
+    var extensions = opts.extensions || Object.keys(require.extensions);
     var basedir = opts.basedir || path.dirname(caller());
 
     opts.paths = opts.paths || [];

--- a/readme.markdown
+++ b/readme.markdown
@@ -82,7 +82,7 @@ default `opts` values:
 {
     paths: [],
     basedir: __dirname,
-    extensions: [ '.js' ],
+    extensions: Object.keys(require.extensions),
     readFile: fs.readFile,
     isFile: function isFile(file, cb) {
         fs.stat(file, function (err, stat) {
@@ -136,7 +136,7 @@ default `opts` values:
 {
     paths: [],
     basedir: __dirname,
-    extensions: [ '.js' ],
+    extensions: Object.keys(require.extensions),
     readFileSync: fs.readFileSync,
     isFile: function isFile(file) {
         try {


### PR DESCRIPTION
Fixes #137, Addresses #134, & Fixes https://github.com/substack/tape/issues/395 by using default `require.extensions` collection instead of the magic Array `['.js']`

Closes #166.