### PR TITLE
Make loadAsFileSync() work the same as async loadAsFile()

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -44,6 +44,16 @@ module.exports = function (x, options) {
     throw err;
 
     function loadAsFileSync(x) {
+        var pkg = loadpkg(path.dirname(x));
+
+        if (pkg && pkg.dir && pkg.pkg && opts.pathFilter) {
+            var rfile = path.relative(pkg.dir, x);
+            var r = opts.pathFilter(pkg.pkg, x, rfile);
+            if (r) {
+                x = path.resolve(pkg.dir, r);
+            }
+        }
+
         if (isFile(x)) {
             return x;
         }
@@ -54,6 +64,30 @@ module.exports = function (x, options) {
                 return file;
             }
         }
+    }
+
+    function loadpkg(dir) {
+        if (dir === '' || dir === '/' || (/[/\\]node_modules[/\\]*$/).test(dir)) {
+            return null;
+        }
+
+        var pkgfile = path.join(dir, 'package.json');
+
+        if (!isFile(pkgfile)) {
+            return loadpkg(path.dirname(dir));
+        }
+
+        var body = readFileSync(pkgfile);
+
+        try {
+            var pkg = JSON.parse(body);
+        } catch (jsonErr) {}
+
+        if (pkg && opts.packageFilter) {
+            pkg = opts.packageFilter(pkg, pkgfile);
+        }
+
+        return { pkg: pkg, dir: dir };
     }
 
     function loadAsDirectorySync(x) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -50,7 +50,7 @@ module.exports = function (x, options) {
             var rfile = path.relative(pkg.dir, x);
             var r = opts.pathFilter(pkg.pkg, x, rfile);
             if (r) {
-                x = path.resolve(pkg.dir, r);
+                x = path.resolve(pkg.dir, r); // eslint-disable-line no-param-reassign
             }
         }
 
@@ -67,9 +67,11 @@ module.exports = function (x, options) {
     }
 
     function loadpkg(dir) {
-        if (dir === '' || dir === '/' || (/[/\\]node_modules[/\\]*$/).test(dir)) {
-            return null;
+        if (dir === '' || dir === '/') return;
+        if (process.platform === 'win32' && (/^\w:[/\\]*$/).test(dir)) {
+            return;
         }
+        if (/[/\\]node_modules[/\\]*$/.test(dir)) return;
 
         var pkgfile = path.join(dir, 'package.json');
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -115,6 +115,12 @@ options are:
 
 * `opts.packageFilter(pkg, pkgfile)` - transform the parsed package.json contents before looking at the "main" field
 
+* `opts.pathFilter(pkg, path, relativePath)` - transform a path within a package
+  * pkg - package data
+  * path - the path being resolved
+  * relativePath - the path relative from the package.json location
+  * returns - a relative path that will be joined from the package.json location
+
 * opts.paths - require.paths array to use if nothing is found on the normal `node_modules` recursive walk (probably don't use this)
 
 * opts.moduleDirectory - directory (or directories) in which to recursively look for modules. default: `"node_modules"`

--- a/test/pathfilter.js
+++ b/test/pathfilter.js
@@ -50,9 +50,15 @@ test('#62: deep module references and the pathFilter', function (t) {
     });
 
     t.test('deep/ref alt', function (st) {
-        st.plan(4);
+        st.plan(8);
 
         var pathFilter = pathFilterFactory(st);
+
+        var res = resolve.sync(
+            'deep/ref',
+            { basedir: resolverDir, pathFilter: pathFilter }
+        );
+        st.equal(res, path.join(resolverDir, 'node_modules/deep/alt.js'));
 
         resolve(
             'deep/ref',
@@ -60,6 +66,7 @@ test('#62: deep module references and the pathFilter', function (t) {
             function (err, res, pkg) {
                 if (err) st.fail(err);
                 st.equal(res, path.join(resolverDir, 'node_modules/deep/alt.js'));
+                st.end();
             }
         );
     });


### PR DESCRIPTION
Fixes #142.

It works fine on CodeSandbox since the end of November. Although not being familiar with the project, I might have missed something.

