### PR TITLE
support opts.package in non-relative lookups

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -185,12 +185,12 @@ module.exports = function resolve(x, options, callback) {
         var dir = dirs[0];
 
         var file = path.join(dir, x);
-        loadAsFile(file, undefined, onfile);
+        loadAsFile(file, opts.package, onfile);
 
         function onfile(err, m, pkg) {
             if (err) return cb(err);
             if (m) return cb(null, m, pkg);
-            loadAsDirectory(path.join(dir, x), undefined, ondir);
+            loadAsDirectory(path.join(dir, x), opts.package, ondir);
         }
 
         function ondir(err, n, pkg) {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -55,7 +55,7 @@ test('bar', function (t) {
     resolve('foo', { basedir: dir + '/bar', 'package': { main: 'bar' } }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, path.join(dir, 'bar/node_modules/foo/index.js'));
-        t.equal(pkg, undefined);
+        t.equal(pkg.main, 'bar');
     });
 });
 
@@ -113,7 +113,7 @@ test('biz', function (t) {
     resolve('tiv', { basedir: dir + '/grux', 'package': { main: 'grux' } }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, path.join(dir, 'tiv/index.js'));
-        t.equal(pkg, undefined);
+        t.equal(pkg.main, 'grux');
     });
 
     resolve('tiv', { basedir: dir + '/garply' }, function (err, res, pkg) {
@@ -125,7 +125,7 @@ test('biz', function (t) {
     resolve('tiv', { basedir: dir + '/garply', 'package': { main: './lib' } }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, path.join(dir, 'tiv/index.js'));
-        t.equal(pkg, undefined);
+        t.equal(pkg.main, './lib');
     });
 
     resolve('grux', { basedir: dir + '/tiv' }, function (err, res, pkg) {
@@ -137,7 +137,7 @@ test('biz', function (t) {
     resolve('grux', { basedir: dir + '/tiv', 'package': { main: 'tiv' } }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, path.join(dir, 'grux/index.js'));
-        t.equal(pkg, undefined);
+        t.equal(pkg.main, 'tiv');
     });
 
     resolve('garply', { basedir: dir + '/tiv' }, function (err, res, pkg) {


### PR DESCRIPTION
It looks like the non-relative lookup [here](https://github.com/browserify/resolve/blob/v1.5.0/lib/async.js#L43) was missed when adding the `opts.package` feature (which I would like to utilize).