### PR TITLE
correctly resolve paths that are on networked drives

### DIFF
--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -18,7 +18,7 @@ var getNodeModulesDirs = function getNodeModulesDirs(absoluteStart, modules) {
 
     return paths.reduce(function (dirs, aPath) {
         return dirs.concat(modules.map(function (moduleDir) {
-            return path.join(prefix, aPath, moduleDir);
+            return path.resolve(prefix, aPath, moduleDir);
         }));
     }, []);
 };

--- a/test/node-modules-paths.js
+++ b/test/node-modules-paths.js
@@ -118,4 +118,26 @@ test('node-modules-paths', function (t) {
 
         t.end();
     });
+
+    t.test('combine paths correctly on Windows', function (t) {
+        var start = 'C:\\Users\\username\\myProject\\src';
+        var paths = [];
+        var moduleDirectories = ['node_modules', start];
+        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectories });
+
+        t.equal(dirs.indexOf(path.resolve(start)) > -1, true, 'should contain start dir');
+
+        t.end();
+    });
+
+    t.test('combine paths correctly on non-Windows', { skip: process.platform === 'win32' }, function (t) {
+        var start = '/Users/username/git/myProject/src';
+        var paths = [];
+        var moduleDirectories = ['node_modules', '/Users/username/git/myProject/src'];
+        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectories });
+
+        t.equal(dirs.indexOf(path.resolve(start)) > -1, true, 'should contain start dir');
+
+        t.end();
+    });
 });


### PR DESCRIPTION
This is to fix issue #155 where paths don't resolve when it refers to a networked location. The leading backslash gets stripped off which turns paths such as '\\\\ip\\dir' into '\\ip\dir'.