### PR TITLE
add priority field to support 

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -77,7 +77,8 @@ options are:
 * opts.preserveSymlinks - if true, doesn't resolve `basedir` to real path before resolving.
 This is the way Node resolves dependencies when executed with the [--preserve-symlinks](https://nodejs.org/api/all.html#cli_preserve_symlinks) flag.
 
-default `opts` values:
+* opts.priority - priority to resolve file. Default value is main field. Use `module` to replace when you need.
+  default `opts` values:
 
 ```js
 {


### PR DESCRIPTION
webpack3 or other  build tools have already support module field in package.json  so it's quite import to upport that.