### PR TITLE
[Fix] resolution when `filename` option is passed

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -61,12 +61,12 @@ module.exports = function resolve(x, options, callback) {
     var res;
     function validBasedir() {
         if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(x)) {
-            res = path.resolve(parent, x);
+            res = path.resolve(basedir, x);
             if (x === '..' || x.slice(-1) === '/') res += '/';
-            if (/\/$/.test(x) && res === parent) {
+            if (/\/$/.test(x) && res === basedir) {
                 loadAsDirectory(res, opts.package, onfile);
             } else loadAsFile(res, opts.package, onfile);
-        } else loadNodeModules(x, parent, function (err, n, pkg) {
+        } else loadNodeModules(x, basedir, function (err, n, pkg) {
             if (err) cb(err);
             else if (core[x]) return cb(null, x);
             else if (n) return cb(null, n, pkg);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -44,14 +44,14 @@ module.exports = function (x, options) {
     }
 
     if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(x)) {
-        var res = path.resolve(parent, x);
+        var res = path.resolve(basedir, x);
         if (x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
         if (m) return m;
     } else if (core[x]) {
         return x;
     } else {
-        var n = loadNodeModulesSync(x, parent);
+        var n = loadNodeModulesSync(x, basedir);
         if (n) return n;
     }
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -3,7 +3,7 @@ var test = require('tape');
 var resolve = require('../');
 
 test('async foo', function (t) {
-    t.plan(11);
+    t.plan(12);
     var dir = path.join(__dirname, 'resolver');
 
     resolve('./foo', { basedir: dir }, function (err, res, pkg) {
@@ -28,6 +28,11 @@ test('async foo', function (t) {
         if (err) t.fail(err);
         t.equal(res, path.join(dir, 'foo.js'));
         t.equal(pkg.main, 'resolver');
+    });
+
+    resolve('./foo', { basedir: dir, filename: path.join(dir, 'baz.js') }, function (err, res) {
+        if (err) t.fail(err);
+        t.equal(res, path.join(dir, 'foo.js'));
     });
 
     resolve('foo', { basedir: dir }, function (err) {

--- a/test/resolver_sync.js
+++ b/test/resolver_sync.js
@@ -15,6 +15,11 @@ test('foo', function (t) {
         path.join(dir, 'foo.js')
     );
 
+    t.equal(
+        resolve.sync('./foo.js', { basedir: dir, filename: path.join(dir, 'bar.js') }),
+        path.join(dir, 'foo.js')
+    );
+
     t.throws(function () {
         resolve.sync('foo', { basedir: dir });
     });


### PR DESCRIPTION
PR #162 introduced a `parent` variable that contains either the full
filename of the requiring module or the `basedir`. Some of the places
where `basedir` was used were updated to use `parent` instead, but
that's not correct; the `path.resolve()` calls would receive the full
filename instead of the directory name.

This patch reverts the improper `parent` uses to `basedir`.