### PR TITLE
Implements `useProcessResolution`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
+var useProcessResolution = require('./use-process-resolution.js');
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
@@ -36,6 +37,10 @@ module.exports = function resolve(x, options, callback) {
         return process.nextTick(function () {
             cb(err);
         });
+    }
+
+    if (opts.useProcessResolution) {
+        useProcessResolution(opts);
     }
 
     var isFile = opts.isFile || defaultIsFile;

--- a/lib/async.js
+++ b/lib/async.js
@@ -230,6 +230,7 @@ module.exports = function resolve(x, options, callback) {
         }
     }
     function loadNodeModules(x, start, cb) {
-        processDirs(cb, nodeModulesPaths(x, start, opts));
+        opts.request = x;
+        processDirs(cb, nodeModulesPaths(start, opts));
     }
 };

--- a/lib/async.js
+++ b/lib/async.js
@@ -225,6 +225,6 @@ module.exports = function resolve(x, options, callback) {
         }
     }
     function loadNodeModules(x, start, cb) {
-        processDirs(cb, nodeModulesPaths(start, opts));
+        processDirs(cb, nodeModulesPaths(x, start, opts));
     }
 };

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var parse = path.parse || require('path-parse');
 
-module.exports = function nodeModulesPaths(x, start, opts) {
+module.exports = function nodeModulesPaths(start, opts) {
     var modules = opts && opts.moduleDirectory
         ? [].concat(opts.moduleDirectory)
         : ['node_modules'];
@@ -46,7 +46,7 @@ module.exports = function nodeModulesPaths(x, start, opts) {
 
     if (opts && opts.paths) {
         if (typeof opts.paths === 'function') {
-            dirs = dirs.concat(opts.paths(x, absoluteStart));
+            dirs = dirs.concat(opts.paths(absoluteStart, opts));
         } else {
             dirs = dirs.concat(opts.paths);
         }

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -22,7 +22,7 @@ module.exports = function nodeModulesPaths(start, opts) {
 
     var dirs = [];
 
-    if (!opts || typeof opts.useNodeModules === 'undefined' || opts.useNodeModules) {
+    if (!opts || !opts.skipNodeModules) {
         var prefix = '/';
         if ((/^([A-Za-z]:)/).test(absoluteStart)) {
             prefix = '';

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -20,25 +20,37 @@ module.exports = function nodeModulesPaths(start, opts) {
         }
     }
 
-    var prefix = '/';
-    if ((/^([A-Za-z]:)/).test(absoluteStart)) {
-        prefix = '';
-    } else if ((/^\\\\/).test(absoluteStart)) {
-        prefix = '\\\\';
+    var dirs = [];
+
+    if (!opts || typeof opts.useNodeModules === 'undefined' || opts.useNodeModules) {
+        var prefix = '/';
+        if ((/^([A-Za-z]:)/).test(absoluteStart)) {
+            prefix = '';
+        } else if ((/^\\\\/).test(absoluteStart)) {
+            prefix = '\\\\';
+        }
+
+        var paths = [absoluteStart];
+        var parsed = parse(absoluteStart);
+        while (parsed.dir !== paths[paths.length - 1]) {
+            paths.push(parsed.dir);
+            parsed = parse(parsed.dir);
+        }
+
+        dirs = paths.reduce(function (dirs, aPath) {
+            return dirs.concat(modules.map(function (moduleDir) {
+                return path.join(prefix, aPath, moduleDir);
+            }));
+        }, []);
     }
 
-    var paths = [absoluteStart];
-    var parsed = parse(absoluteStart);
-    while (parsed.dir !== paths[paths.length - 1]) {
-        paths.push(parsed.dir);
-        parsed = parse(parsed.dir);
+    if (opts && opts.paths) {
+        if (typeof opts.paths === 'function') {
+            dirs = dirs.concat(opts.paths(absoluteStart));
+        } else {
+            dirs = dirs.concat(opts.paths);
+        }
     }
 
-    var dirs = paths.reduce(function (dirs, aPath) {
-        return dirs.concat(modules.map(function (moduleDir) {
-            return path.join(prefix, aPath, moduleDir);
-        }));
-    }, []);
-
-    return opts && opts.paths ? dirs.concat(opts.paths) : dirs;
+    return dirs;
 };

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var parse = path.parse || require('path-parse');
 
-module.exports = function nodeModulesPaths(start, opts) {
+module.exports = function nodeModulesPaths(x, start, opts) {
     var modules = opts && opts.moduleDirectory
         ? [].concat(opts.moduleDirectory)
         : ['node_modules'];
@@ -46,7 +46,7 @@ module.exports = function nodeModulesPaths(start, opts) {
 
     if (opts && opts.paths) {
         if (typeof opts.paths === 'function') {
-            dirs = dirs.concat(opts.paths(absoluteStart));
+            dirs = dirs.concat(opts.paths(x, absoluteStart));
         } else {
             dirs = dirs.concat(opts.paths);
         }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -137,7 +137,7 @@ module.exports = function (x, options) {
     }
 
     function loadNodeModulesSync(x, start) {
-        var dirs = nodeModulesPaths(start, opts);
+        var dirs = nodeModulesPaths(x, start, opts);
         for (var i = 0; i < dirs.length; i++) {
             var dir = dirs[i];
             var m = loadAsFileSync(path.join(dir, '/', x));

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -143,7 +143,8 @@ module.exports = function (x, options) {
     }
 
     function loadNodeModulesSync(x, start) {
-        var dirs = nodeModulesPaths(x, start, opts);
+        opts.request = x;
+        var dirs = nodeModulesPaths(start, opts);
         for (var i = 0; i < dirs.length; i++) {
             var dir = dirs[i];
             var m = loadAsFileSync(path.join(dir, '/', x));

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
+var useProcessResolution = require('./use-process-resolution.js');
 
 var defaultIsFile = function isFile(file) {
     try {
@@ -29,6 +30,11 @@ module.exports = function (x, options) {
         throw new TypeError('Path must be a string.');
     }
     var opts = options || {};
+
+    if (opts.useProcessResolution) {
+        useProcessResolution(opts);
+    }
+
     var isFile = opts.isFile || defaultIsFile;
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFileSync = opts.readFileSync || fs.readFileSync;

--- a/lib/use-process-resolution.js
+++ b/lib/use-process-resolution.js
@@ -1,0 +1,27 @@
+var path = require('path');
+
+module.exports = function processResolution(opts) {
+    if (process.versions.pnp) {
+        var pnp = require('pnpapi');
+
+        opts.preserveSymlinks = true;
+        opts.useNodeModules = false;
+        opts.paths = function (request, basedir) {
+            // Extract the name of the package being requested (1=full name, 2=scope name, 3=local name)
+            var parts = request.match(/^((?:(@[^\/]+)\/)?([^\/]+))/);
+
+            // This is guaranteed to return the path to the "package.json" file from the given package
+            var manifestPath = pnp.resolveToUnqualified(parts[1] + '/package.json', basedir);
+
+            // The first dirname strips the package.json, the second strips the local named folder
+            var nodeModules = path.dirname(path.dirname(manifestPath));
+
+            // Strips the scope named folder if needed
+            if (parts[2]) {
+                nodeModules = path.dirname(nodeModules);
+            }
+
+            return [nodeModules];
+        };
+    }
+};

--- a/lib/use-process-resolution.js
+++ b/lib/use-process-resolution.js
@@ -5,7 +5,7 @@ module.exports = function processResolution(opts) {
         var pnp = require('pnpapi');
 
         opts.preserveSymlinks = true;
-        opts.useNodeModules = false;
+        opts.skipNodeModules = true;
         opts.paths = function (basedir, opts) {
             if (!opts || !opts.request) {
                 throw new Error('Missing request option');

--- a/lib/use-process-resolution.js
+++ b/lib/use-process-resolution.js
@@ -6,9 +6,13 @@ module.exports = function processResolution(opts) {
 
         opts.preserveSymlinks = true;
         opts.useNodeModules = false;
-        opts.paths = function (request, basedir) {
+        opts.paths = function (basedir, opts) {
+            if (!opts || !opts.request) {
+                throw new Error('Missing request option');
+            }
+
             // Extract the name of the package being requested (1=full name, 2=scope name, 3=local name)
-            var parts = request.match(/^((?:(@[^\/]+)\/)?([^\/]+))/);
+            var parts = opts.request.match(/^((?:(@[^/]+)\/)?([^/]+))/);
 
             // This is guaranteed to return the path to the "package.json" file from the given package
             var manifestPath = pnp.resolveToUnqualified(parts[1] + '/package.json', basedir);

--- a/readme.markdown
+++ b/readme.markdown
@@ -74,6 +74,10 @@ options are:
 
 * opts.paths - require.paths array to use if nothing is found on the normal `node_modules` recursive walk (probably don't use this)
 
+* opts.useProcessResolution - instructs `resolve` to use the same resolution algorithm than the one used by the current process
+
+* opts.useNodeModules - instructs `resolve` to automatically locate the `node_modules` directories. default: true
+
 * opts.moduleDirectory - directory (or directories) in which to recursively look for modules. default: `"node_modules"`
 
 * opts.preserveSymlinks - if true, doesn't resolve `basedir` to real path before resolving.

--- a/readme.markdown
+++ b/readme.markdown
@@ -73,10 +73,14 @@ options are:
   * returns - a relative path that will be joined from the package.json location
 
 * opts.paths - require.paths array to use if nothing is found on the normal `node_modules` recursive walk (probably don't use this)
+For advanced users, `paths` can also be a `opts.paths(start, opts)` function
+  * start - lookup path
+  * opts - the resolution options
+  * opts.request - the import specifier being resolved
 
 * opts.useProcessResolution - instructs `resolve` to use the same resolution algorithm than the one used by the current process
 
-* opts.useNodeModules - instructs `resolve` to automatically locate the `node_modules` directories. default: true
+* opts.skipNodeModules - instructs `resolve` to ignore any `node_modules` directory when doing the resolution
 
 * opts.moduleDirectory - directory (or directories) in which to recursively look for modules. default: `"node_modules"`
 

--- a/test/node-modules-paths.js
+++ b/test/node-modules-paths.js
@@ -54,9 +54,9 @@ test('node-modules-paths', function (t) {
         t.end();
     });
 
-    t.test('with useNodeModules=false option', function (t) {
+    t.test('with skipNodeModules=true option', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths(start, { useNodeModules: false });
+        var dirs = nodeModulesPaths(start, { skipNodeModules: true });
 
         t.deepEqual(dirs, [], 'no node_modules was computed');
 

--- a/test/node-modules-paths.js
+++ b/test/node-modules-paths.js
@@ -38,7 +38,7 @@ var verifyDirs = function verifyDirs(t, start, dirs, moduleDirectories, paths) {
 test('node-modules-paths', function (t) {
     t.test('no options', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths('pkg', start);
+        var dirs = nodeModulesPaths(start);
 
         verifyDirs(t, start, dirs);
 
@@ -47,7 +47,7 @@ test('node-modules-paths', function (t) {
 
     t.test('empty options', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths('pkg', start, {});
+        var dirs = nodeModulesPaths(start, {});
 
         verifyDirs(t, start, dirs);
 
@@ -56,7 +56,7 @@ test('node-modules-paths', function (t) {
 
     t.test('with useNodeModules=false option', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths('pkg', start, { useNodeModules: false });
+        var dirs = nodeModulesPaths(start, { useNodeModules: false });
 
         t.deepEqual(dirs, [], 'no node_modules was computed');
 
@@ -66,7 +66,7 @@ test('node-modules-paths', function (t) {
     t.test('with paths=array option', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
-        var dirs = nodeModulesPaths('pkg', start, { paths: paths });
+        var dirs = nodeModulesPaths(start, { paths: paths });
 
         verifyDirs(t, start, dirs, null, paths);
 
@@ -74,16 +74,14 @@ test('node-modules-paths', function (t) {
     });
 
     t.test('with paths=function option', function (t) {
-        var paths = function paths(absoluteStart) {
-            return [path.join(absoluteStart, 'not node modules')];
+        var paths = function paths(absoluteStart, opts) {
+            return [path.join(absoluteStart, 'not node modules', opts.request)];
         };
 
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths('pkg', start, { paths: paths });
+        var dirs = nodeModulesPaths(start, { paths: paths, request: 'pkg' });
 
-        console.log(dirs);
-
-        verifyDirs(t, start, dirs, null, [path.join(start, 'not node modules')]);
+        verifyDirs(t, start, dirs, null, [path.join(start, 'not node modules', 'pkg')]);
 
         t.end();
     });
@@ -91,7 +89,7 @@ test('node-modules-paths', function (t) {
     t.test('with moduleDirectory option', function (t) {
         var start = path.join(__dirname, 'resolver');
         var moduleDirectory = 'not node modules';
-        var dirs = nodeModulesPaths('pkg', start, { moduleDirectory: moduleDirectory });
+        var dirs = nodeModulesPaths(start, { moduleDirectory: moduleDirectory });
 
         verifyDirs(t, start, dirs, moduleDirectory);
 
@@ -102,7 +100,7 @@ test('node-modules-paths', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
         var moduleDirectory = 'not node modules';
-        var dirs = nodeModulesPaths('pkg', start, { paths: paths, moduleDirectory: moduleDirectory });
+        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectory });
 
         verifyDirs(t, start, dirs, moduleDirectory, paths);
 
@@ -113,7 +111,7 @@ test('node-modules-paths', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
         var moduleDirectories = ['not node modules', 'other modules'];
-        var dirs = nodeModulesPaths('pkg', start, { paths: paths, moduleDirectory: moduleDirectories });
+        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectories });
 
         verifyDirs(t, start, dirs, moduleDirectories, paths);
 

--- a/test/node-modules-paths.js
+++ b/test/node-modules-paths.js
@@ -38,7 +38,7 @@ var verifyDirs = function verifyDirs(t, start, dirs, moduleDirectories, paths) {
 test('node-modules-paths', function (t) {
     t.test('no options', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths(start);
+        var dirs = nodeModulesPaths('pkg', start);
 
         verifyDirs(t, start, dirs);
 
@@ -47,7 +47,7 @@ test('node-modules-paths', function (t) {
 
     t.test('empty options', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths(start, {});
+        var dirs = nodeModulesPaths('pkg', start, {});
 
         verifyDirs(t, start, dirs);
 
@@ -56,7 +56,7 @@ test('node-modules-paths', function (t) {
 
     t.test('with useNodeModules=false option', function (t) {
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths(start, { useNodeModules: false });
+        var dirs = nodeModulesPaths('pkg', start, { useNodeModules: false });
 
         t.deepEqual(dirs, [], 'no node_modules was computed');
 
@@ -66,7 +66,7 @@ test('node-modules-paths', function (t) {
     t.test('with paths=array option', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
-        var dirs = nodeModulesPaths(start, { paths: paths });
+        var dirs = nodeModulesPaths('pkg', start, { paths: paths });
 
         verifyDirs(t, start, dirs, null, paths);
 
@@ -79,7 +79,7 @@ test('node-modules-paths', function (t) {
         };
 
         var start = path.join(__dirname, 'resolver');
-        var dirs = nodeModulesPaths(start, { paths: paths });
+        var dirs = nodeModulesPaths('pkg', start, { paths: paths });
 
         console.log(dirs);
 
@@ -91,7 +91,7 @@ test('node-modules-paths', function (t) {
     t.test('with moduleDirectory option', function (t) {
         var start = path.join(__dirname, 'resolver');
         var moduleDirectory = 'not node modules';
-        var dirs = nodeModulesPaths(start, { moduleDirectory: moduleDirectory });
+        var dirs = nodeModulesPaths('pkg', start, { moduleDirectory: moduleDirectory });
 
         verifyDirs(t, start, dirs, moduleDirectory);
 
@@ -102,7 +102,7 @@ test('node-modules-paths', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
         var moduleDirectory = 'not node modules';
-        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectory });
+        var dirs = nodeModulesPaths('pkg', start, { paths: paths, moduleDirectory: moduleDirectory });
 
         verifyDirs(t, start, dirs, moduleDirectory, paths);
 
@@ -113,7 +113,7 @@ test('node-modules-paths', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
         var moduleDirectories = ['not node modules', 'other modules'];
-        var dirs = nodeModulesPaths(start, { paths: paths, moduleDirectory: moduleDirectories });
+        var dirs = nodeModulesPaths('pkg', start, { paths: paths, moduleDirectory: moduleDirectories });
 
         verifyDirs(t, start, dirs, moduleDirectories, paths);
 

--- a/test/node-modules-paths.js
+++ b/test/node-modules-paths.js
@@ -7,6 +7,11 @@ var nodeModulesPaths = require('../lib/node-modules-paths');
 
 var verifyDirs = function verifyDirs(t, start, dirs, moduleDirectories, paths) {
     var moduleDirs = [].concat(moduleDirectories || 'node_modules');
+    if (paths) {
+        for (var k = 0; k < paths.length; ++k) {
+            moduleDirs.push(path.basename(paths[k]));
+        }
+    }
 
     var foundModuleDirs = {};
     var uniqueDirs = {};
@@ -20,7 +25,7 @@ var verifyDirs = function verifyDirs(t, start, dirs, moduleDirectories, paths) {
     }
     t.equal(keys(parsedDirs).length >= start.split(path.sep).length, true, 'there are >= dirs than "start" has');
     var foundModuleDirNames = keys(foundModuleDirs);
-    t.deepEqual(foundModuleDirNames, moduleDirs.concat(paths || []), 'all desired module dirs were found');
+    t.deepEqual(foundModuleDirNames, moduleDirs, 'all desired module dirs were found');
     t.equal(keys(uniqueDirs).length, dirs.length, 'all dirs provided were unique');
 
     var counts = {};
@@ -49,12 +54,36 @@ test('node-modules-paths', function (t) {
         t.end();
     });
 
-    t.test('with paths option', function (t) {
+    t.test('with useNodeModules=false option', function (t) {
+        var start = path.join(__dirname, 'resolver');
+        var dirs = nodeModulesPaths(start, { useNodeModules: false });
+
+        t.deepEqual(dirs, [], 'no node_modules was computed');
+
+        t.end();
+    });
+
+    t.test('with paths=array option', function (t) {
         var start = path.join(__dirname, 'resolver');
         var paths = ['a', 'b'];
         var dirs = nodeModulesPaths(start, { paths: paths });
 
         verifyDirs(t, start, dirs, null, paths);
+
+        t.end();
+    });
+
+    t.test('with paths=function option', function (t) {
+        var paths = function paths(absoluteStart) {
+            return [path.join(absoluteStart, 'not node modules')];
+        };
+
+        var start = path.join(__dirname, 'resolver');
+        var dirs = nodeModulesPaths(start, { paths: paths });
+
+        console.log(dirs);
+
+        verifyDirs(t, start, dirs, null, [path.join(start, 'not node modules')]);
 
         t.end();
     });


### PR DESCRIPTION
This PR implements the `useProcessResolution` option we discussed with @ljharb. I've split the feature in three commits:

- The first one simply extends the options to allow 1/ the node resolution algorithm to be optionally disabled, and 2/ to compute extraneous paths based on the starting directory (rather than only a fixed list).

- The second one slightly changes the internals so that the `nodeModulesPaths` function has access to the request being processed. This makes it possible to compute extraneous paths based on the request itself (not only on the starting directory).

- The third one wraps the feature by implementing a `useProcessResolution` option that tweaks the option set to match what should be used by the current process (in this case, I've added builtin support for Plug'n'Play).

As you can see, the feature is quite self-contained and generic enough to be used in other cases than simply Plug'n'Play. It should be compatible with both `pathFilter` and `packageFilter`, since it happens earlier in the resolution process.