### PR TITLE
Implements a "normalize-options" pseudo-hook

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
+var normalizeOptions = require('./normalize-options.js');
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
@@ -26,8 +27,8 @@ var defaultIsDir = function isDirectory(dir, cb) {
 
 module.exports = function resolve(x, options, callback) {
     var cb = callback;
-    var opts = options || {};
-    if (typeof opts === 'function') {
+    var opts = options;
+    if (typeof options === 'function') {
         cb = opts;
         opts = {};
     }
@@ -37,6 +38,8 @@ module.exports = function resolve(x, options, callback) {
             cb(err);
         });
     }
+
+    opts = normalizeOptions(x, opts);
 
     var isFile = opts.isFile || defaultIsFile;
     var isDirectory = opts.isDirectory || defaultIsDir;

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -1,0 +1,10 @@
+module.exports = function (x, opts) {
+    /**
+     * This file is purposefully a passthrough. It's expected that third-party
+     * environments will override it at runtime in order to inject special logic
+     * into `resolve` (by manipulating the options). One such example is the PnP
+     * code path in Yarn.
+     */
+
+    return opts || {};
+};

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
+var normalizeOptions = require('./normalize-options.js');
 
 var defaultIsFile = function isFile(file) {
     try {
@@ -28,7 +29,8 @@ module.exports = function (x, options) {
     if (typeof x !== 'string') {
         throw new TypeError('Path must be a string.');
     }
-    var opts = options || {};
+    var opts = normalizeOptions(x, options);
+
     var isFile = opts.isFile || defaultIsFile;
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFileSync = opts.readFileSync || fs.readFileSync;


### PR DESCRIPTION
Split out of #170.

This PR adds a noop function used to normalize the options passed to `resolve`. The goal is for third-party environments like PnP to be able to override this file (and only this file) to set new default options more adapted to the current process resolution.