### PR TITLE
Add files key to only publish required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "url": "git://github.com/browserify/resolve.git"
   },
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "keywords": [
     "resolve",
     "require",


### PR DESCRIPTION
I noticed the tests etc being published to npm, this PR fixes that.

### OLD

npm notice
npm notice 📦  resolve@1.8.1
npm notice === Tarball Contents ===
npm notice 925B   package.json
npm notice 13B    .eslintignore
npm notice 924B   .eslintrc
npm notice 7.3kB  .travis.yml
npm notice 1.2kB  appveyor.yml
npm notice 222B   index.js
npm notice 1.1kB  LICENSE
npm notice 5.8kB  readme.markdown
npm notice 155B   example/async.js
npm notice 103B   example/sync.js
npm notice 8.0kB  lib/async.js
npm notice 354B   lib/caller.js
npm notice 1.7kB  lib/core.js
npm notice 2.1kB  lib/core.json
npm notice 1.3kB  lib/node-modules-paths.js
npm notice 348B   lib/normalize-options.js
npm notice 4.5kB  lib/sync.js
npm notice 86B    test/.eslintrc
npm notice 2.7kB  test/core.js
npm notice 799B   test/dotdot.js
npm notice 39B    test/dotdot/abc/index.js
npm notice 29B    test/dotdot/index.js
npm notice 352B   test/faulty_basedir.js
npm notice 975B   test/filter_sync.js
npm notice 1.2kB  test/filter.js
npm notice 2.0kB  test/mock_sync.js
npm notice 5.2kB  test/mock.js
npm notice 1.6kB  test/module_dir.js
npm notice 51B    test/module_dir/xmodules/aaa/index.js
npm notice 51B    test/module_dir/ymodules/aaa/index.js
npm notice 51B    test/module_dir/zmodules/bbb/main.js
npm notice 24B    test/module_dir/zmodules/bbb/package.json
npm notice 2.0kB  test/node_path.js
npm notice 22B    test/node_path/x/aaa/index.js
npm notice 22B    test/node_path/x/ccc/index.js
npm notice 22B    test/node_path/y/bbb/index.js
npm notice 23B    test/node_path/y/ccc/index.js
npm notice 3.2kB  test/node-modules-paths.js
npm notice 182B   test/nonstring.js
npm notice 909B   test/pathfilter_sync.js
npm notice 2.2kB  test/pathfilter.js
npm notice 0      test/pathfilter/deep_ref/main.js
npm notice 646B   test/precedence.js
npm notice 24B    test/precedence/aaa.js
npm notice 25B    test/precedence/aaa/index.js
npm notice 28B    test/precedence/aaa/main.js
npm notice 24B    test/precedence/bbb.js
npm notice 44B    test/precedence/bbb/main.js
npm notice 7.5kB  test/resolver_sync.js
npm notice 13.0kB test/resolver.js
npm notice 0      test/resolver/baz/doom.js
npm notice 26B    test/resolver/baz/package.json
npm notice 20B    test/resolver/baz/quux.js
npm notice 0      test/resolver/browser_field/a.js
npm notice 0      test/resolver/browser_field/b.js
npm notice 63B    test/resolver/browser_field/package.json
npm notice 1B     test/resolver/cup.coffee
npm notice 20B    test/resolver/dot_main/index.js
npm notice 20B    test/resolver/dot_main/package.json
npm notice 20B    test/resolver/dot_slash_main/index.js
npm notice 21B    test/resolver/dot_slash_main/package.json
npm notice 20B    test/resolver/foo.js
npm notice 116B   test/resolver/incorrect_main/index.js
npm notice 27B    test/resolver/incorrect_main/package.json
npm notice 0      test/resolver/mug.coffee
npm notice 0      test/resolver/mug.js
npm notice 0      test/resolver/other_path/lib/other-lib.js
npm notice 0      test/resolver/other_path/root.js
npm notice 20B    test/resolver/quux/foo/index.js
npm notice 21B    test/resolver/same_names/foo.js
npm notice 20B    test/resolver/same_names/foo/index.js
npm notice 0      test/resolver/symlinked/_/node_modules/foo.js
npm notice 0      test/resolver/symlinked/_/symlink_target/.gitkeep
npm notice 111B   test/resolver/without_basedir/main.js
npm notice 1.1kB  test/shadowed_core.js
npm notice 0      test/shadowed_core/node_modules/util/index.js
npm notice 353B   test/subdirs.js
npm notice 1.9kB  test/symlinks.js
npm notice === Tarball Details ===
npm notice name:          resolve
npm notice version:       1.8.1
npm notice filename:      resolve-1.8.1.tgz
npm notice package size:  16.4 kB
npm notice unpacked size: 84.9 kB
npm notice shasum:        434ccd44bc1a5930131a74e9c939622bef0a8e2b
npm notice integrity:     sha512-Hc7IJYsO2FJwB[...]YBr9c6DtXqdvA==
npm notice total files:   78
npm notice
resolve-1.8.1.tgz

### NEW

npm notice
npm notice 📦  resolve@1.8.1
npm notice === Tarball Contents ===
npm notice 969B  package.json
npm notice 222B  index.js
npm notice 1.1kB LICENSE
npm notice 5.8kB readme.markdown
npm notice 8.0kB lib/async.js
npm notice 354B  lib/caller.js
npm notice 1.7kB lib/core.js
npm notice 2.1kB lib/core.json
npm notice 1.3kB lib/node-modules-paths.js
npm notice 348B  lib/normalize-options.js
npm notice 4.5kB lib/sync.js
npm notice === Tarball Details ===
npm notice name:          resolve
npm notice version:       1.8.1
npm notice filename:      resolve-1.8.1.tgz
npm notice package size:  6.9 kB
npm notice unpacked size: 26.3 kB
npm notice shasum:        b157b77178e3bff873507f723af62ed00408c8f7
npm notice integrity:     sha512-bkQoX8d2JaJqv[...]3Y4iBrsbbbDRw==
npm notice total files:   11
npm notice