### PR TITLE
include only the lib/ folder in the package, exclude tests and examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "node",
     "module"
   ],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "prepublish": "safe-publish-latest",
     "lint": "eslint .",


### PR DESCRIPTION
This npm module has 56kByte overhead with tests and examples, not needed for the functionality of the module itself. Fixed this by adding the 'files' field in the package.json.