### PR TITLE
Restrict which files are packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "node",
     "module"
   ],
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "scripts": {
     "prepublish": "safe-publish-latest",
     "lint": "eslint .",


### PR DESCRIPTION
Keeping npm modules as light as possible will speed up download times and disk space usage of users.

Adding the `files` key in `package.json` will let npm know which files to package. More info here: https://docs.npmjs.com/files/package.json#files

If I missed files required to use this module, please let me know and I will update this PR.

Npm pack results:
Before
```
npm notice === Tarball Details ===
npm notice name:          resolve
npm notice version:       1.9.0
npm notice filename:      resolve-1.9.0.tgz
npm notice package size:  18.3 kB
npm notice unpacked size: 92.3 kB
npm notice integrity:     sha512-K0N68lfSB1jWh[...]vyd7JamKd1vug==
npm notice total files:   85
```
After
```
npm notice === Tarball Details ===
npm notice name:          resolve
npm notice version:       1.9.0
npm notice filename:      resolve-1.9.0.tgz
npm notice package size:  7.4 kB
npm notice unpacked size: 28.6 kB
npm notice shasum:        53bde3e8bcf146287f3003b006190895f0cd10dc
npm notice integrity:     sha512-hnhiX8nZHj87g[...]uYZ2V+XlrYJnA==
npm notice total files:   11
```