### PR TITLE
packages.json: Add "files" attributes for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "tap": "0.4.13",
     "tape": "^4.9.1"
   },
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "license": "MIT",
   "author": {
     "name": "James Halliday",


### PR DESCRIPTION
Add "files" attributes for npm to only pack necessary files.
This is can reduce package size a lot under `node_modules`.

see https://docs.npmjs.com/misc/developers

```shell
$ du -sh node_modules/resolve/*
 12K	node_modules/resolve/CHANGELOG.md
4.0K	node_modules/resolve/LICENSE
4.0K	node_modules/resolve/appveyor.yml
4.0K	node_modules/resolve/changelog.hbs
8.0K	node_modules/resolve/example
4.0K	node_modules/resolve/index.js
 36K	node_modules/resolve/lib
4.0K	node_modules/resolve/package.json
8.0K	node_modules/resolve/readme.markdown
244K	node_modules/resolve/test
```

will become to:
```shell
$ du -sh node_modules/resolve/*
4.0K	node_modules/resolve/LICENSE
4.0K	node_modules/resolve/index.js
 36K	node_modules/resolve/lib
```