### PR TITLE
[Fix] TypeError: Path must be a string. Received undefined

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -46,7 +46,7 @@ module.exports = function resolve(x, options, callback) {
     if (opts.preserveSymlinks === false) {
         fs.realpath(absoluteStart, function (realPathErr, realStart) {
             if (realPathErr && realPathErr.code !== 'ENOENT') cb(err);
-            else init(realStart);
+            else init(realPathErr ? absoluteStart : realStart);
         });
     } else {
         init(absoluteStart);

--- a/test/faulty_basedir.js
+++ b/test/faulty_basedir.js
@@ -1,4 +1,5 @@
 var test = require('tape');
+var path = require('path');
 var resolve = require('../');
 
 test('faulty basedir must produce error in windows', { skip: process.platform !== 'win32' }, function (t) {
@@ -7,7 +8,22 @@ test('faulty basedir must produce error in windows', { skip: process.platform !=
     var resolverDir = 'C:\\a\\b\\c\\d';
 
     resolve('tape/lib/test.js', { basedir: resolverDir }, function (err, res, pkg) {
-        t.equal(true, !!err);
+        t.equal(!!err, true);
     });
+});
 
+test('non-existent basedir should not throw when preserveSymlinks is false', function (t) {
+    t.plan(2);
+
+    var opts = {
+        basedir: path.join(path.sep, 'unreal', 'path', 'that', 'does', 'not', 'exist'),
+        preserveSymlinks: false
+    };
+
+    var module = './dotdot/abc';
+
+    resolve(module, opts, function (err, res) {
+        t.equal(err.code, 'MODULE_NOT_FOUND');
+        t.equal(res, undefined);
+    });
 });


### PR DESCRIPTION
Patches an issue that would cause a type error to be thrown when `fs.realpath` would return an `ENOENT` and `preserveSymlinks` was set to `false`.

Closes #181.