### PR TITLE
[New] resolve.sync can resolve to options.fallback if resolution fails

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -73,6 +73,7 @@ module.exports = function (x, options) {
     }
 
     if (core[x]) return x;
+    if ('fallback' in options && typeof options.fallback === 'string') return options.fallback;
 
     var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
     err.code = 'MODULE_NOT_FOUND';

--- a/test/fallback.js
+++ b/test/fallback.js
@@ -1,0 +1,34 @@
+var test = require('tape');
+var resolve = require('../');
+
+test('fallback sync', function (t) {
+    var fallback = '<NOT_FOUND>';
+    var filename = 'nonExistentFile_' + Math.random().toString();
+
+    var invalidValues = [
+        undefined,
+        null,
+        false,
+        true,
+        42,
+        Symbol('fallback sync'),
+        [],
+        function () {},
+        {}
+    ];
+
+    t.plan(2 + invalidValues.length);
+
+    var a = resolve.sync(filename, { fallback: fallback });
+    t.equal(a, fallback);
+
+    var b = resolve.sync(filename, { fallback: '' });
+    t.equal(b, '');
+
+    invalidValues.forEach(function (invalidValue) {
+        function run() {
+            resolve.sync(filename, { fallback: invalidValue });
+        }
+        t.throws(run, 'should have thrown an error for invalid value ' + String(invalidValue));
+    });
+});


### PR DESCRIPTION
Added a new optional field `fallback` in `resolve.sync`'s `options`
parameter. If given,  `fallback` must be a `string` value for it to be
considered in the resolution process. It can be an empty string.

If provided, and if the module resolution is about to fail, the fallback
value is returned instead, and no exception is thrown.

Old users of the API won't be affected by this change, and new user will
be able to avoid a possibly costly exception throw -- especially relevant
in scenarios where there's a considerable amount of modules
(direct or transitive) to resolve.

Please see `tests/fallback.js` for a brief example.