### PR TITLE
update `resolve.sync` to support `pkg.module`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -200,21 +200,23 @@ module.exports = function resolve(x, options, callback) {
                     pkg = opts.packageFilter(pkg, pkgfile, x);
                 }
 
-                if (pkg.main) {
-                    if (typeof pkg.main !== 'string') {
+                var pkgEntry = pkg.module || pkg.main;
+
+                if (pkgEntry) {
+                    if (typeof pkgEntry !== 'string') {
                         var mainError = new TypeError('package “' + pkg.name + '” `main` must be a string');
                         mainError.code = 'INVALID_PACKAGE_MAIN';
                         return cb(mainError);
                     }
-                    if (pkg.main === '.' || pkg.main === './') {
-                        pkg.main = 'index';
+                    if (pkgEntry === '.' || pkgEntry === './') {
+                        pkgEntry = 'index';
                     }
-                    loadAsFile(path.resolve(x, pkg.main), pkg, function (err, m, pkg) {
+                    loadAsFile(path.resolve(x, pkgEntry), pkg, function (err, m, pkg) {
                         if (err) return cb(err);
                         if (m) return cb(null, m, pkg);
                         if (!pkg) return loadAsFile(path.join(x, 'index'), pkg, cb);
 
-                        var dir = path.resolve(x, pkg.main);
+                        var dir = path.resolve(x, pkgEntry);
                         loadAsDirectory(dir, pkg, function (err, n, pkg) {
                             if (err) return cb(err);
                             if (n) return cb(null, n, pkg);


### PR DESCRIPTION
Attempt to support [pkg.module](https://github.com/rollup/rollup/wiki/pkg.module).
Not sure if there was a similar PR before, but it may be helpful for the post-compilation.