### PR TITLE
[Refactor] check existence of `node_modules`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -233,8 +233,14 @@ module.exports = function resolve(x, options, callback) {
         if (dirs.length === 0) return cb(null, undefined);
         var dir = dirs[0];
 
-        var file = path.join(dir, x);
-        loadAsFile(file, opts.package, onfile);
+        isDirectory(dir, isdir);
+
+        function isdir(err, isdir) {
+            if (err) return cb(err);
+            if (!isdir) return processDirs(cb, dirs.slice(1));
+            var file = path.join(dir, x);
+            loadAsFile(file, opts.package, onfile);
+        }
 
         function onfile(err, m, pkg) {
             if (err) return cb(err);

--- a/test/mock.js
+++ b/test/mock.js
@@ -108,6 +108,7 @@ test('mock package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {
@@ -142,6 +143,7 @@ test('mock package from package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {


### PR DESCRIPTION
This offers a small but useful performance improvement by avoiding unnecessary stat calls.

Fixes #116 