### PR TITLE
[refactor] (sync) check existence of node_modules

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -164,10 +164,12 @@ module.exports = function (x, options) {
         var dirs = nodeModulesPaths(start, opts, x);
         for (var i = 0; i < dirs.length; i++) {
             var dir = dirs[i];
-            var m = loadAsFileSync(path.join(dir, '/', x));
-            if (m) return m;
-            var n = loadAsDirectorySync(path.join(dir, '/', x));
-            if (n) return n;
+            if (isDirectory(dir)) {
+                var m = loadAsFileSync(path.join(dir, '/', x));
+                if (m) return m;
+                var n = loadAsDirectorySync(path.join(dir, '/', x));
+                if (n) return n;
+            }
         }
     }
 };

--- a/test/mock_sync.js
+++ b/test/mock_sync.js
@@ -10,6 +10,7 @@ test('mock', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo/bar')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {
@@ -56,6 +57,7 @@ test('mock package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {


### PR DESCRIPTION
This brings the same perf improvements as in 4cf89280c7446b396b67c43900b297b6b3e0907a (https://github.com/browserify/resolve/pull/190) but for the sync version

Refs #116