### PR TITLE
[New] Add `isDirectory`; use to speed up `node_modules` lookups

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -15,6 +15,16 @@ var defaultIsFile = function isFile(file, cb) {
     });
 };
 
+var defaultIsDir = function isDirectory(dir, cb) {
+    fs.stat(dir, function (err, stat) {
+        if (!err) {
+            return cb(null, stat.isDirectory());
+        }
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return cb(null, false);
+        return cb(err);
+    });
+};
+
 module.exports = function resolve(x, options, callback) {
     var cb = callback;
     var opts = options;
@@ -32,6 +42,7 @@ module.exports = function resolve(x, options, callback) {
     opts = normalizeOptions(x, opts);
 
     var isFile = opts.isFile || defaultIsFile;
+    var isDirectory = opts.isDirectory || defaultIsDir;
     var readFile = opts.readFile || fs.readFile;
 
     var extensions = opts.extensions || ['.js'];

--- a/lib/async.js
+++ b/lib/async.js
@@ -219,8 +219,14 @@ module.exports = function resolve(x, options, callback) {
         if (dirs.length === 0) return cb(null, undefined);
         var dir = dirs[0];
 
-        var file = path.join(dir, x);
-        loadAsFile(file, opts.package, onfile);
+        isDirectory(dir, isdir);
+
+        function isdir(err, isdir) {
+            if (err) return cb(err);
+            if (!isdir) return processDirs(cb, dirs.slice(1));
+            var file = path.join(dir, x);
+            loadAsFile(file, opts.package, onfile);
+        }
 
         function onfile(err, m, pkg) {
             if (err) return cb(err);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,6 +15,16 @@ var defaultIsFile = function isFile(file) {
     return stat.isFile() || stat.isFIFO();
 };
 
+var defaultIsDir = function isDirectory(dir) {
+    try {
+        var stat = fs.statSync(dir);
+    } catch (e) {
+        if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
+        throw e;
+    }
+    return stat.isDirectory();
+};
+
 module.exports = function (x, options) {
     if (typeof x !== 'string') {
         throw new TypeError('Path must be a string.');
@@ -23,6 +33,7 @@ module.exports = function (x, options) {
 
     var isFile = opts.isFile || defaultIsFile;
     var readFileSync = opts.readFileSync || fs.readFileSync;
+    var isDirectory = opts.isDirectory || defaultIsDir;
 
     var extensions = opts.extensions || ['.js'];
     var basedir = opts.basedir || path.dirname(caller());

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -156,10 +156,12 @@ module.exports = function (x, options) {
         var dirs = nodeModulesPaths(start, opts, x);
         for (var i = 0; i < dirs.length; i++) {
             var dir = dirs[i];
-            var m = loadAsFileSync(path.join(dir, '/', x));
-            if (m) return m;
-            var n = loadAsDirectorySync(path.join(dir, '/', x));
-            if (n) return n;
+            if (isDirectory(dir)) {
+                var m = loadAsFileSync(path.join(dir, '/', x));
+                if (m) return m;
+                var n = loadAsDirectorySync(path.join(dir, '/', x));
+                if (n) return n;
+            }
         }
     }
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -59,6 +59,8 @@ options are:
 
 * opts.isFile - function to asynchronously test whether a file exists
 
+* opts.isDirectory - function to asynchronously test whether a directory exists
+
 * `opts.packageFilter(pkg, pkgfile)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
   * pkgfile - path to package.json
@@ -101,6 +103,15 @@ default `opts` values:
             return cb(err);
         });
     },
+    isDirectory: function isDirectory(dir, cb) {
+        fs.stat(dir, function (err, stat) {
+            if (!err) {
+                return cb(null, stat.isDirectory());
+            }
+            if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return cb(null, false);
+            return cb(err);
+        });
+    },
     moduleDirectory: 'node_modules',
     preserveSymlinks: true
 }
@@ -120,6 +131,8 @@ options are:
 * opts.readFile - how to read files synchronously
 
 * opts.isFile - function to synchronously test whether a file exists
+
+* opts.isDirectory - function to synchronously test whether a directory exists
 
 * `opts.packageFilter(pkg, dir)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
@@ -156,6 +169,15 @@ default `opts` values:
             throw e;
         }
         return stat.isFile() || stat.isFIFO();
+    },
+    isDirectory: function isDirectory(dir) {
+        try {
+            var stat = fs.statSync(dir);
+        } catch (e) {
+            if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false;
+            throw e;
+        }
+        return stat.isDirectory();
     },
     moduleDirectory: 'node_modules',
     preserveSymlinks: true

--- a/test/mock.js
+++ b/test/mock.js
@@ -8,11 +8,17 @@ test('mock', function (t) {
     var files = {};
     files[path.resolve('/foo/bar/baz.js')] = 'beep';
 
+    var dirs = {};
+    dirs[path.resolve('/foo/bar')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file, cb) {
                 cb(null, Object.prototype.hasOwnProperty.call(files, path.resolve(file)));
+            },
+            isDirectory: function (dir, cb) {
+                cb(null, !!dirs[path.resolve(dir)]);
             },
             readFile: function (file, cb) {
                 cb(null, files[path.resolve(file)]);
@@ -49,11 +55,17 @@ test('mock from package', function (t) {
     var files = {};
     files[path.resolve('/foo/bar/baz.js')] = 'beep';
 
+    var dirs = {};
+    dirs[path.resolve('/foo/bar')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file, cb) {
                 cb(null, Object.prototype.hasOwnProperty.call(files, file));
+            },
+            isDirectory: function (dir, cb) {
+                cb(null, !!dirs[path.resolve(dir)]);
             },
             'package': { main: 'bar' },
             readFile: function (file, cb) {
@@ -94,11 +106,17 @@ test('mock package', function (t) {
         main: './baz.js'
     });
 
+    var dirs = {};
+    dirs[path.resolve('/foo')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file, cb) {
                 cb(null, Object.prototype.hasOwnProperty.call(files, path.resolve(file)));
+            },
+            isDirectory: function (dir, cb) {
+                cb(null, !!dirs[path.resolve(dir)]);
             },
             readFile: function (file, cb) {
                 cb(null, files[path.resolve(file)]);
@@ -122,11 +140,17 @@ test('mock package from package', function (t) {
         main: './baz.js'
     });
 
+    var dirs = {};
+    dirs[path.resolve('/foo')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file, cb) {
                 cb(null, Object.prototype.hasOwnProperty.call(files, path.resolve(file)));
+            },
+            isDirectory: function (dir, cb) {
+                cb(null, !!dirs[path.resolve(dir)]);
             },
             'package': { main: 'bar' },
             readFile: function (file, cb) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -108,6 +108,7 @@ test('mock package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {
@@ -142,6 +143,7 @@ test('mock package from package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {

--- a/test/mock_sync.js
+++ b/test/mock_sync.js
@@ -56,6 +56,7 @@ test('mock package', function (t) {
 
     var dirs = {};
     dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
 
     function opts(basedir) {
         return {

--- a/test/mock_sync.js
+++ b/test/mock_sync.js
@@ -8,14 +8,20 @@ test('mock', function (t) {
     var files = {};
     files[path.resolve('/foo/bar/baz.js')] = 'beep';
 
+    var dirs = {};
+    dirs[path.resolve('/foo/bar')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file) {
-                return Object.prototype.hasOwnProperty.call(files, file);
+                return Object.prototype.hasOwnProperty.call(files, path.resolve(file));
+            },
+            isDirectory: function (dir) {
+                return !!dirs[path.resolve(dir)];
             },
             readFileSync: function (file) {
-                return files[file];
+                return files[path.resolve(file)];
             }
         };
     }
@@ -48,14 +54,20 @@ test('mock package', function (t) {
         main: './baz.js'
     });
 
+    var dirs = {};
+    dirs[path.resolve('/foo')] = true;
+
     function opts(basedir) {
         return {
             basedir: path.resolve(basedir),
             isFile: function (file) {
-                return Object.prototype.hasOwnProperty.call(files, file);
+                return Object.prototype.hasOwnProperty.call(files, path.resolve(file));
+            },
+            isDirectory: function (dir) {
+                return !!dirs[path.resolve(dir)];
             },
             readFileSync: function (file) {
-                return files[file];
+                return files[path.resolve(file)];
             }
         };
     }


### PR DESCRIPTION
This is a backport of 4cf89280c7446b396b67c43900b297b6b3e0907a and fa11d4804cdd89250404c5efff5256755887331c (https://github.com/browserify/resolve/pull/190 and https://github.com/browserify/resolve/pull/191) to the 1.x branch.

This adds the `isDirectory` option which is needed to drive the directory lookups.

This offers a small but useful performance improvement by avoiding unnecessary stat calls.

Because of the added option this is a MINOR change.

Refs #116
