### PR TITLE
[Docs] fix CI status badge

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -5,7 +5,7 @@ algorithm](https://nodejs.org/api/modules.html#modules_all_together)
 such that you can `require.resolve()` on behalf of a file asynchronously and
 synchronously
 
-[![build status](https://secure.travis-ci.org/browserify/node-resolve.png)](http://travis-ci.org/browserify/node-resolve)
+[![build status](https://secure.travis-ci.org/browserify/resolve.png)](http://travis-ci.org/browserify/resolve)
 
 # example
 


### PR DESCRIPTION
This PR changes the URL for the CI status badge to the right one.