### PR TITLE
Do not leak Object.prototype when checking for core modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-var core = require('./lib/core');
 var async = require('./lib/async');
-async.core = core;
-async.isCore = function isCore(x) { return core[x]; };
+async.core = require('./lib/core');
+async.isCore = require('./lib/is-core');
 async.sync = require('./lib/sync');
 
 exports = async;

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,9 +1,9 @@
-var core = require('./core');
 var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
+var isCore = require('./is-core');
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
@@ -98,7 +98,7 @@ module.exports = function resolve(x, options, callback) {
             } else loadAsFile(res, opts.package, onfile);
         } else loadNodeModules(x, basedir, function (err, n, pkg) {
             if (err) cb(err);
-            else if (core[x]) return cb(null, x);
+            else if (isCore(x)) return cb(null, x);
             else if (n) {
                 return maybeUnwrapSymlink(n, opts, function (err, realN) {
                     if (err) {

--- a/lib/is-core.js
+++ b/lib/is-core.js
@@ -1,0 +1,5 @@
+var core = require('./core');
+
+module.exports = function isCore(x) {
+    return Object.prototype.hasOwnProperty.call(core, x);
+};

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,4 +1,4 @@
-var core = require('./core');
+var isCore = require('./is-core');
 var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
@@ -68,14 +68,14 @@ module.exports = function (x, options) {
         if (x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
         if (m) return maybeUnwrapSymlink(m, opts);
-    } else if (core[x]) {
+    } else if (isCore(x)) {
         return x;
     } else {
         var n = loadNodeModulesSync(x, absoluteStart);
         if (n) return maybeUnwrapSymlink(n, opts);
     }
 
-    if (core[x]) return x;
+    if (isCore(x)) return x;
 
     var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
     err.code = 'MODULE_NOT_FOUND';

--- a/test/core.js
+++ b/test/core.js
@@ -10,6 +10,9 @@ test('core modules', function (t) {
 
         st.ok(!resolve.isCore('seq'));
         st.ok(!resolve.isCore('../'));
+
+        st.ok(!resolve.isCore('toString'));
+
         st.end();
     });
 

--- a/test/symlinks.js
+++ b/test/symlinks.js
@@ -101,6 +101,10 @@ test('async symlink from node_modules to other dir when preserveSymlinks = false
 });
 
 test('packageFilter', function (t) {
+    function relative(x) {
+        return path.relative(__dirname, x);
+    }
+
     function testPackageFilter(preserveSymlinks) {
         return function (st) {
             st.plan(5);
@@ -120,13 +124,13 @@ test('packageFilter', function (t) {
                 }
             });
             st.equal(
-                actualPath.replace(__dirname + '/', ''),
-                preserveSymlinks ? destMain : sourceMain,
+                relative(actualPath),
+                path.normalize(preserveSymlinks ? destMain : sourceMain),
                 'sync: actual path is correct'
             );
             st.deepEqual(
-                map(packageFilterPath, function (x) { return x.replace(__dirname + '/', ''); }),
-                preserveSymlinks ? [destPkg, destPkg] : [sourcePkg, sourcePkg],
+                map(packageFilterPath, relative),
+                map(preserveSymlinks ? [destPkg, destPkg] : [sourcePkg, sourcePkg], path.normalize),
                 'sync: packageFilter pkgfile arg is correct'
             );
 
@@ -143,13 +147,13 @@ test('packageFilter', function (t) {
                 function (err, actualPath) {
                     st.error(err, 'no error');
                     st.equal(
-                        actualPath.replace(__dirname + '/', ''),
-                        preserveSymlinks ? destMain : sourceMain,
+                        relative(actualPath),
+                        path.normalize(preserveSymlinks ? destMain : sourceMain),
                         'async: actual path is correct'
                     );
                     st.deepEqual(
-                        map(asyncPackageFilterPath, function (x) { return x.replace(__dirname + '/', ''); }),
-                        preserveSymlinks ? [destPkg, destPkg, destPkg] : [sourcePkg, sourcePkg, sourcePkg],
+                        map(packageFilterPath, relative),
+                        map(preserveSymlinks ? [destPkg, destPkg] : [sourcePkg, sourcePkg], path.normalize),
                         'async: packageFilter pkgfile arg is correct'
                     );
                 }


### PR DESCRIPTION
Context:

I'm trying to use Yarn 2 (with PnP) in Babel.
Babel depends on `browserify`, which depends on `browser-resolve` which depends on an older version of `resolve` without PnP support (1.1.7).

I tried to upgrade `resolve` in `browser-resolve`, but a test started failing because it checked for `toString` resolution.

Since this worked in `resolve` 1.1.7, was the behavior changed on purpose?