### PR TITLE
Fixes isCore async check

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -96,9 +96,10 @@ module.exports = function resolve(x, options, callback) {
             if ((/\/$/).test(x) && res === basedir) {
                 loadAsDirectory(res, opts.package, onfile);
             } else loadAsFile(res, opts.package, onfile);
+        } else if (isCore(x)) {
+            return cb(null, x);
         } else loadNodeModules(x, basedir, function (err, n, pkg) {
             if (err) cb(err);
-            else if (isCore(x)) return cb(null, x);
             else if (n) {
                 return maybeUnwrapSymlink(n, opts, function (err, realN) {
                     if (err) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -75,8 +75,6 @@ module.exports = function (x, options) {
         if (n) return maybeUnwrapSymlink(n, opts);
     }
 
-    if (isCore(x)) return x;
-
     var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
     err.code = 'MODULE_NOT_FOUND';
     throw err;


### PR DESCRIPTION
There's a slight difference between the sync and async codepaths in that the `isCore` async check is done in the `loadNodeModules` callback rather than right before the call.

I'm not sure how to test it though since it has the same behaviour except that packageIterator (from #205) won't be called with core packages.