### PR TITLE
fix: correct behavior when requiring `.` with same name

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
 matrix:
   # fast_finish: true
   allow_failures:
+    - nodejs_version: "5" # due to windows npm bug, registry-side
     - nodejs_version: "0.8"
     - nodejs_version: "0.6"
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -101,7 +101,7 @@ module.exports = function resolve(x, options, callback) {
     function validBasedir(basedir) {
         if ((/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/).test(x)) {
             res = path.resolve(basedir, x);
-            if (x === '..' || x.slice(-1) === '/') res += '/';
+            if (x === '.' || x === '..' || x.slice(-1) === '/') res += '/';
             if ((/\/$/).test(x) && res === basedir) {
                 loadAsDirectory(res, opts.package, onfile);
             } else loadAsFile(res, opts.package, onfile);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -74,7 +74,7 @@ module.exports = function resolveSync(x, options) {
 
     if ((/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/).test(x)) {
         var res = path.resolve(absoluteStart, x);
-        if (x === '..' || x.slice(-1) === '/') res += '/';
+        if (x === '.' || x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
         if (m) return maybeUnwrapSymlink(m, opts);
     } else if (isCore(x)) {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -315,6 +315,22 @@ test('#52 - incorrectly resolves module-paths like "./someFolder/" when there is
     });
 });
 
+test('#211 - incorrectly resolves module-paths like "." when from inside a folder with a sibling file of the same name', function (t) {
+    t.plan(2);
+
+    var dir = path.join(__dirname, 'resolver');
+
+    resolve('./', { basedir: path.join(dir, 'same_names/foo') }, function (err, res, pkg) {
+        if (err) t.fail(err);
+        t.equal(res, path.join(dir, 'same_names/foo/index.js'));
+    });
+
+    resolve('.', { basedir: path.join(dir, 'same_names/foo') }, function (err, res, pkg) {
+        if (err) t.fail(err);
+        t.equal(res, path.join(dir, 'same_names/foo/index.js'));
+    });
+});
+
 test('async: #121 - treating an existing file as a dir when no basedir', function (t) {
     var testFile = path.basename(__filename);
 

--- a/test/resolver_sync.js
+++ b/test/resolver_sync.js
@@ -238,6 +238,20 @@ test('#52 - incorrectly resolves module-paths like "./someFolder/" when there is
     t.end();
 });
 
+test('#211 - incorrectly resolves module-paths like "." when from inside a folder with a sibling file of the same name', function (t) {
+    var dir = path.join(__dirname, 'resolver');
+
+    t.equal(
+        resolve.sync('./', { basedir: path.join(dir, 'same_names/foo') }),
+        path.join(dir, 'same_names/foo/index.js')
+    );
+    t.equal(
+        resolve.sync('.', { basedir: path.join(dir, 'same_names/foo') }),
+        path.join(dir, 'same_names/foo/index.js')
+    );
+    t.end();
+});
+
 test('sync: #121 - treating an existing file as a dir when no basedir', function (t) {
     var testFile = path.basename(__filename);
 


### PR DESCRIPTION
Fixes #211.