### PR TITLE
feat: use native `realpath` if available to unwrap symlinks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ build: off
 
 environment:
   matrix:
+    - nodejs_version: "13"
     - nodejs_version: "12"
     - nodejs_version: "11"
     - nodejs_version: "10"
@@ -23,8 +24,8 @@ environment:
 matrix:
   # fast_finish: true
   allow_failures:
-    - nodejs_version: "5" # due to windows npm bug, registry-side
     - nodejs_version: "0.8"
+      platform: x86
     - nodejs_version: "0.6"
 
 platform:
@@ -33,17 +34,31 @@ platform:
 
 # Install scripts. (runs after repo cloning)
 install:
- # Fix symlinks in working copy (see https://github.com/appveyor/ci/issues/650#issuecomment-186592582) / https://github.com/charleskorn/batect/commit/d08986802ec43086902958c4ee7e57ff3e71dbef
- - git config core.symlinks true
- - git reset --hard
- # Get the latest stable version of Node.js or io.js
- - ps: Install-Product node $env:nodejs_version $env:platform
- - IF %nodejs_version% EQU 0.6 npm config set strict-ssl false && npm -g install npm@1.3
- - IF %nodejs_version% EQU 0.8 npm config set strict-ssl false && npm -g install npm@1.4.28 && npm install -g npm@4.5
- - set PATH=%APPDATA%\npm;%PATH%
- #- IF %nodejs_version% NEQ 0.6 AND %nodejs_version% NEQ 0.8 npm -g install npm
- # install modules
- - npm install
+  # Fix symlinks in working copy (see https://github.com/appveyor/ci/issues/650#issuecomment-186592582) / https://github.com/charleskorn/batect/commit/d08986802ec43086902958c4ee7e57ff3e71dbef
+  - git config core.symlinks true
+  - git reset --hard
+  # Get the latest stable version of Node.js or io.js
+  - ps: if ($env:nodejs_version -ne '0.6') { Install-Product node $env:nodejs_version $env:platform }
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
+  - IF %nodejs_version% EQU 0.6 npm config set strict-ssl false && npm -g install npm@1.3
+  - IF %nodejs_version% EQU 0.8 npm config set strict-ssl false && npm -g install npm@1.4.28 && npm install -g npm@4.5
+  - IF %nodejs_version% EQU 1 npm -g install npm@2.9
+  - IF %nodejs_version% EQU 2 npm -g install npm@4
+  - IF %nodejs_version% EQU 3 npm -g install npm@4
+  - IF %nodejs_version% EQU 4 npm -g install npm@5.3
+  - IF %nodejs_version% EQU 5 npm -g install npm@5.3
+  - IF %nodejs_version% EQU 6 npm -g install npm@6.9
+  - IF %nodejs_version% EQU 7 npm -g install npm
+  - IF %nodejs_version% EQU 8 npm -g install npm
+  - IF %nodejs_version% EQU 9 npm -g install npm@6.9
+  - IF %nodejs_version% EQU 10 npm -g install npm
+  - IF %nodejs_version% EQU 11 npm -g install npm
+  - IF %nodejs_version% EQU 12 npm -g install npm
+  - IF %nodejs_version% EQU 13 npm -g install npm
+  - set PATH=%APPDATA%\npm;%PATH%
+  #- IF %nodejs_version% NEQ 0.6 AND %nodejs_version% NEQ 0.8 npm -g install npm
+  # install modules
+  - npm install
 
 # Post-install test scripts.
 test_script:

--- a/lib/async.js
+++ b/lib/async.js
@@ -5,6 +5,8 @@ var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 var isCore = require('./is-core');
 
+var realpath = typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
+
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
         if (!err) {
@@ -27,7 +29,7 @@ var defaultIsDir = function isDirectory(dir, cb) {
 
 var maybeUnwrapSymlink = function maybeUnwrapSymlink(x, opts, cb) {
     if (!opts || !opts.preserveSymlinks) {
-        fs.realpath(x, function (realPathErr, realPath) {
+        realpath(x, function (realPathErr, realPath) {
             if (realPathErr && realPathErr.code !== 'ENOENT') cb(realPathErr);
             else cb(null, realPathErr ? x : realPath);
         });

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -5,6 +5,8 @@ var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 
+var realpath = typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
+
 var defaultIsFile = function isFile(file) {
     try {
         var stat = fs.statSync(file);
@@ -28,7 +30,7 @@ var defaultIsDir = function isDirectory(dir) {
 var maybeUnwrapSymlink = function maybeUnwrapSymlink(x, opts) {
     if (!opts || !opts.preserveSymlinks) {
         try {
-            return fs.realpathSync(x);
+            return realpath(x);
         } catch (realPathErr) {
             if (realPathErr.code !== 'ENOENT') {
                 throw realPathErr;


### PR DESCRIPTION
As discussed in https://github.com/facebook/jest/issues/9776

Docs: https://nodejs.org/api/fs.html#fs_fs_realpath_native_path_options_callback

didn't bother with `process.bindings` as we really shouldn't use those