### PR TITLE
[New] `sync`/`async`: add `realpath`/`realpathSync` options

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -5,7 +5,7 @@ var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 var isCore = require('./is-core');
 
-var realpath = fs.realpath && typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
+var realpathFS = fs.realpath && typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
@@ -27,12 +27,16 @@ var defaultIsDir = function isDirectory(dir, cb) {
     });
 };
 
-var maybeUnwrapSymlink = function maybeUnwrapSymlink(x, opts, cb) {
+var defaultRealpath = function realpath(x, cb) {
+    realpathFS(x, function (realpathErr, realPath) {
+        if (realpathErr && realpathErr.code !== 'ENOENT') cb(realpathErr);
+        else cb(null, realpathErr ? x : realPath);
+    });
+};
+
+var maybeRealpath = function maybeRealpath(realpath, x, opts, cb) {
     if (!opts || !opts.preserveSymlinks) {
-        realpath(x, function (realPathErr, realPath) {
-            if (realPathErr && realPathErr.code !== 'ENOENT') cb(realPathErr);
-            else cb(null, realPathErr ? x : realPath);
-        });
+        realpath(x, cb);
     } else {
         cb(null, x);
     }
@@ -65,6 +69,7 @@ module.exports = function resolve(x, options, callback) {
     var isFile = opts.isFile || defaultIsFile;
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFile = opts.readFile || fs.readFile;
+    var realpath = opts.realpath || defaultRealpath;
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
@@ -76,7 +81,8 @@ module.exports = function resolve(x, options, callback) {
     // ensure that `basedir` is an absolute path at this point, resolving against the process' current working directory
     var absoluteStart = path.resolve(basedir);
 
-    maybeUnwrapSymlink(
+    maybeRealpath(
+        realpath,
         absoluteStart,
         opts,
         function (err, realStart) {
@@ -112,7 +118,7 @@ module.exports = function resolve(x, options, callback) {
         } else loadNodeModules(x, basedir, function (err, n, pkg) {
             if (err) cb(err);
             else if (n) {
-                return maybeUnwrapSymlink(n, opts, function (err, realN) {
+                return maybeRealpath(realpath, n, opts, function (err, realN) {
                     if (err) {
                         cb(err);
                     } else {
@@ -133,7 +139,7 @@ module.exports = function resolve(x, options, callback) {
         else loadAsDirectory(res, function (err, d, pkg) {
             if (err) cb(err);
             else if (d) {
-                maybeUnwrapSymlink(d, opts, function (err, realD) {
+                maybeRealpath(realpath, d, opts, function (err, realD) {
                     if (err) {
                         cb(err);
                     } else {
@@ -197,7 +203,7 @@ module.exports = function resolve(x, options, callback) {
         }
         if ((/[/\\]node_modules[/\\]*$/).test(dir)) return cb(null);
 
-        maybeUnwrapSymlink(dir, opts, function (unwrapErr, pkgdir) {
+        maybeRealpath(realpath, dir, opts, function (unwrapErr, pkgdir) {
             if (unwrapErr) return loadpkg(path.dirname(dir), cb);
             var pkgfile = path.join(pkgdir, 'package.json');
             isFile(pkgfile, function (err, ex) {
@@ -225,7 +231,7 @@ module.exports = function resolve(x, options, callback) {
             fpkg = opts.package;
         }
 
-        maybeUnwrapSymlink(x, opts, function (unwrapErr, pkgdir) {
+        maybeRealpath(realpath, x, opts, function (unwrapErr, pkgdir) {
             if (unwrapErr) return loadAsDirectory(path.dirname(x), fpkg, cb);
             var pkgfile = path.join(pkgdir, 'package.json');
             isFile(pkgfile, function (err, ex) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -5,7 +5,7 @@ var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 
-var realpath = fs.realpathSync && typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
+var realpathFS = fs.realpathSync && typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
 
 var defaultIsFile = function isFile(file) {
     try {
@@ -27,15 +27,20 @@ var defaultIsDir = function isDirectory(dir) {
     return stat.isDirectory();
 };
 
-var maybeUnwrapSymlink = function maybeUnwrapSymlink(x, opts) {
-    if (!opts || !opts.preserveSymlinks) {
-        try {
-            return realpath(x);
-        } catch (realPathErr) {
-            if (realPathErr.code !== 'ENOENT') {
-                throw realPathErr;
-            }
+var defaultRealpathSync = function realpathSync(x) {
+    try {
+        return realpathFS(x);
+    } catch (realpathErr) {
+        if (realpathErr.code !== 'ENOENT') {
+            throw realpathErr;
         }
+    }
+    return x;
+};
+
+var maybeRealpathSync = function maybeRealpathSync(realpathSync, x, opts) {
+    if (!opts || !opts.preserveSymlinks) {
+        return realpathSync(x);
     }
     return x;
 };
@@ -57,6 +62,7 @@ module.exports = function resolveSync(x, options) {
     var isFile = opts.isFile || defaultIsFile;
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFileSync = opts.readFileSync || fs.readFileSync;
+    var realpathSync = opts.realpathSync || defaultRealpathSync;
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
@@ -66,7 +72,7 @@ module.exports = function resolveSync(x, options) {
     opts.paths = opts.paths || [];
 
     // ensure that `basedir` is an absolute path at this point, resolving against the process' current working directory
-    var absoluteStart = maybeUnwrapSymlink(path.resolve(basedir), opts);
+    var absoluteStart = maybeRealpathSync(realpathSync, path.resolve(basedir), opts);
 
     if (opts.basedir && !isDirectory(absoluteStart)) {
         var dirError = new TypeError('Provided basedir "' + opts.basedir + '" is not a directory' + (opts.preserveSymlinks ? '' : ', or a symlink to a directory'));
@@ -78,12 +84,12 @@ module.exports = function resolveSync(x, options) {
         var res = path.resolve(absoluteStart, x);
         if (x === '.' || x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
-        if (m) return maybeUnwrapSymlink(m, opts);
+        if (m) return maybeRealpathSync(realpathSync, m, opts);
     } else if (isCore(x)) {
         return x;
     } else {
         var n = loadNodeModulesSync(x, absoluteStart);
-        if (n) return maybeUnwrapSymlink(n, opts);
+        if (n) return maybeRealpathSync(realpathSync, n, opts);
     }
 
     var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
@@ -120,7 +126,7 @@ module.exports = function resolveSync(x, options) {
         }
         if ((/[/\\]node_modules[/\\]*$/).test(dir)) return;
 
-        var pkgfile = path.join(isDirectory(dir) ? maybeUnwrapSymlink(dir, opts) : dir, 'package.json');
+        var pkgfile = path.join(isDirectory(dir) ? maybeRealpathSync(realpathSync, dir, opts) : dir, 'package.json');
 
         if (!isFile(pkgfile)) {
             return loadpkg(path.dirname(dir));
@@ -140,7 +146,7 @@ module.exports = function resolveSync(x, options) {
     }
 
     function loadAsDirectorySync(x) {
-        var pkgfile = path.join(isDirectory(x) ? maybeUnwrapSymlink(x, opts) : x, '/package.json');
+        var pkgfile = path.join(isDirectory(x) ? maybeRealpathSync(realpathSync, x, opts) : x, '/package.json');
         if (isFile(pkgfile)) {
             try {
                 var body = readFileSync(pkgfile, 'UTF8');

--- a/readme.markdown
+++ b/readme.markdown
@@ -61,6 +61,8 @@ options are:
 
 * opts.isDirectory - function to asynchronously test whether a file exists and is a directory
 
+* opts.realpath - function to asynchronously resolve a potential symlink to its real path
+
 * `opts.packageFilter(pkg, pkgfile, dir)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
   * pkgfile - path to package.json
@@ -117,6 +119,13 @@ default `opts` values:
             return cb(err);
         });
     },
+    realpath: function realpath(file, cb) {
+       var realpath = typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
+       realpath(file, function (realPathErr, realPath) {
+           if (realPathErr && realPathErr.code !== 'ENOENT') cb(realPathErr);
+           else cb(null, realPathErr ? file : realPath);
+       });
+   },
     moduleDirectory: 'node_modules',
     preserveSymlinks: false
 }
@@ -138,6 +147,8 @@ options are:
 * opts.isFile - function to synchronously test whether a file exists
 
 * opts.isDirectory - function to synchronously test whether a file exists and is a directory
+
+* opts.realpathSync - function to synchronously resolve a potential symlink to its real path
 
 * `opts.packageFilter(pkg, pkgfile, dir)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
@@ -194,6 +205,17 @@ default `opts` values:
             throw e;
         }
         return stat.isDirectory();
+    },
+    realpathSync: function realpathSync(file) {
+        try {
+            var realpath = typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
+            return realpath(file);
+        } catch (realPathErr) {
+            if (realPathErr.code !== 'ENOENT') {
+                throw realPathErr;
+            }
+        }
+        return file;
     },
     moduleDirectory: 'node_modules',
     preserveSymlinks: false

--- a/test/mock_sync.js
+++ b/test/mock_sync.js
@@ -23,6 +23,9 @@ test('mock', function (t) {
             },
             readFileSync: function (file) {
                 return files[path.resolve(file)];
+            },
+            realpathSync: function (file) {
+                return file;
             }
         };
     }
@@ -70,6 +73,9 @@ test('mock package', function (t) {
             },
             readFileSync: function (file) {
                 return files[path.resolve(file)];
+            },
+            realpathSync: function (file) {
+                return file;
             }
         };
     }
@@ -77,5 +83,60 @@ test('mock package', function (t) {
     t.equal(
         resolve.sync('bar', opts('/foo')),
         path.resolve('/foo/node_modules/bar/baz.js')
+    );
+});
+
+test('symlinked', function (t) {
+    t.plan(2);
+
+    var files = {};
+    files[path.resolve('/foo/bar/baz.js')] = 'beep';
+    files[path.resolve('/foo/bar/symlinked/baz.js')] = 'beep';
+
+    var dirs = {};
+    dirs[path.resolve('/foo/bar')] = true;
+    dirs[path.resolve('/foo/bar/symlinked')] = true;
+
+    function opts(basedir) {
+        return {
+            preserveSymlinks: false,
+            basedir: path.resolve(basedir),
+            isFile: function (file) {
+                return Object.prototype.hasOwnProperty.call(files, path.resolve(file));
+            },
+            isDirectory: function (dir) {
+                return !!dirs[path.resolve(dir)];
+            },
+            readFileSync: function (file) {
+                return files[path.resolve(file)];
+            },
+            realpathSync: function (file) {
+                var resolved = path.resolve(file);
+
+                if (resolved.indexOf('symlinked') >= 0) {
+                    return resolved;
+                }
+
+                var ext = path.extname(resolved);
+
+                if (ext) {
+                    var dir = path.dirname(resolved);
+                    var base = path.basename(resolved);
+                    return path.join(dir, 'symlinked', base);
+                } else {
+                    return path.join(resolved, 'symlinked');
+                }
+            }
+        };
+    }
+
+    t.equal(
+        resolve.sync('./baz', opts('/foo/bar')),
+        path.resolve('/foo/bar/symlinked/baz.js')
+    );
+
+    t.equal(
+        resolve.sync('./baz.js', opts('/foo/bar')),
+        path.resolve('/foo/bar/symlinked/baz.js')
     );
 });


### PR DESCRIPTION
Not sure how to write tests for this one. Ideas?

I also went with passing the implementation to `maybeUnwrap` so consumer wouldn't have to care about the option, not sure if it's a good idea or not.

(This is probably the one we want in Jest so we can plug in the hacky `process.bindings` one on node 8...)