### PR TITLE
Moving the realpath resolution to a function that uses it, so it doesn't fail on lib/sync import

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -5,7 +5,7 @@ var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 var isCore = require('./is-core');
 
-var realpath = typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
+var realpath = fs.realpath && typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -5,7 +5,7 @@ var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
 var normalizeOptions = require('./normalize-options.js');
 
-var realpath = typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
+var realpath = fs.realpathSync && typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
 
 var defaultIsFile = function isFile(file) {
     try {


### PR DESCRIPTION
https://github.com/browserify/resolve/commit/535ec22acf6d5cc4fa3665ab6dbb6755519e6deb#diff-688ede0ee2da1fa3d89f2fc485f39273R8

This change caused some issues for the users of Cypress Cucumber Preprocessor - https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/issues/362

`putting     "resolve": "1.15.1"`
in package.json resolutions helps.

I'm guessing we never, directly or indirectly, call the `maybeUnwrapSymlink` function so having realpath not being defined was never a problem for us. 

I'd appreciate a tweak here. I'm also guessing we might not the only ones that will bump into this problem in the future. 