### PR TITLE
reduce npm package size by adding files entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
 		"posttest": "npm run test:multirepo && aud --production",
 		"test:multirepo": "cd ./test/resolver/multirepo && npm install && npm test"
 	},
+	"files": [
+		"index.*",
+		"lib/"
+	],
 	"devDependencies": {
 		"@ljharb/eslint-config": "^17.1.0",
 		"array.prototype.map": "^1.0.2",


### PR DESCRIPTION
Add a files entry in package.json to add only files needed for execution to the npm bundle.