### PR TITLE
add 'includeCoreModules' option

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -73,6 +73,7 @@ module.exports = function resolve(x, options, callback) {
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
+    var includeCoreModules = opts.includeCoreModules !== false;
     var basedir = opts.basedir || path.dirname(caller());
     var parent = opts.filename || basedir;
 
@@ -113,7 +114,7 @@ module.exports = function resolve(x, options, callback) {
             if ((/\/$/).test(x) && res === basedir) {
                 loadAsDirectory(res, opts.package, onfile);
             } else loadAsFile(res, opts.package, onfile);
-        } else if (isCore(x)) {
+        } else if (includeCoreModules && isCore(x)) {
             return cb(null, x);
         } else loadNodeModules(x, basedir, function (err, n, pkg) {
             if (err) cb(err);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -66,6 +66,7 @@ module.exports = function resolveSync(x, options) {
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
+    var includeCoreModules = opts.includeCoreModules !== false;
     var basedir = opts.basedir || path.dirname(caller());
     var parent = opts.filename || basedir;
 
@@ -85,7 +86,7 @@ module.exports = function resolveSync(x, options) {
         if (x === '.' || x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
         if (m) return maybeRealpathSync(realpathSync, m, opts);
-    } else if (isCore(x)) {
+    } else if (includeCoreModules && isCore(x)) {
         return x;
     } else {
         var n = loadNodeModulesSync(x, absoluteStart);

--- a/readme.markdown
+++ b/readme.markdown
@@ -61,6 +61,8 @@ options are:
 
 * opts.extensions - array of file extensions to search in order
 
+* opts.includeCoreModules - set to `false` to exclude node core modules (e.g. `fs`) from the search
+
 * opts.readFile - how to read files asynchronously
 
 * opts.isFile - function to asynchronously test whether a file exists
@@ -108,6 +110,7 @@ default `opts` values:
     paths: [],
     basedir: __dirname,
     extensions: ['.js'],
+    includeCoreModules: true,
     readFile: fs.readFile,
     isFile: function isFile(file, cb) {
         fs.stat(file, function (err, stat) {
@@ -149,6 +152,8 @@ options are:
 * opts.basedir - directory to begin resolving from
 
 * opts.extensions - array of file extensions to search in order
+
+* opts.includeCoreModules - set to `false` to exclude node core modules (e.g. `fs`) from the search
 
 * opts.readFile - how to read files synchronously
 
@@ -195,6 +200,7 @@ default `opts` values:
     paths: [],
     basedir: __dirname,
     extensions: ['.js'],
+    includeCoreModules: true,
     readFileSync: fs.readFileSync,
     isFile: function isFile(file) {
         try {

--- a/test/shadowed_core.js
+++ b/test/shadowed_core.js
@@ -36,3 +36,19 @@ test('shadowed core modules return shadow when appending `/` [sync]', function (
     t.equal(res, path.join(__dirname, 'shadowed_core/node_modules/util/index.js'));
 });
 
+test('shadowed core modules return shadow with `includeCoreModules: false`', function (t) {
+    t.plan(2);
+
+    resolve('util', { basedir: path.join(__dirname, 'shadowed_core'), includeCoreModules: false }, function (err, res) {
+        t.ifError(err);
+        t.equal(res, path.join(__dirname, 'shadowed_core/node_modules/util/index.js'));
+    });
+});
+
+test('shadowed core modules return shadow with `includeCoreModules: false` [sync]', function (t) {
+    t.plan(1);
+
+    var res = resolve.sync('util', { basedir: path.join(__dirname, 'shadowed_core'), includeCoreModules: false });
+
+    t.equal(res, path.join(__dirname, 'shadowed_core/node_modules/util/index.js'));
+});


### PR DESCRIPTION
Setting `includeCoreModules: false` makes it possible to resolve as if the core modules did not exist.

This can be useful in a bundler like rollup where the user may be targeting web, where node builtins are not relevant.

Refs https://github.com/rollup/plugins/pull/637