### PR TITLE
[New] add `readPackage` and `readPackageSync`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -42,6 +42,20 @@ var maybeRealpath = function maybeRealpath(realpath, x, opts, cb) {
     }
 };
 
+var defaultReadPackage = function defaultReadPackage(readFile, pkgfile, cb) {
+    readFile(pkgfile, function (readFileErr, body) {
+        if (readFileErr) cb(readFileErr);
+        else {
+            try {
+                var pkg = JSON.parse(body);
+                cb(null, pkg);
+            } catch (jsonErr) {
+                cb(null);
+            }
+        }
+    });
+};
+
 var getPackageCandidates = function getPackageCandidates(x, start, opts) {
     var dirs = nodeModulesPaths(start, opts, x);
     for (var i = 0; i < dirs.length; i++) {
@@ -70,6 +84,13 @@ module.exports = function resolve(x, options, callback) {
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFile = opts.readFile || fs.readFile;
     var realpath = opts.realpath || defaultRealpath;
+    var readPackage = opts.readPackage || defaultReadPackage;
+    if (opts.readFile && opts.readPackage) {
+        var conflictErr = new TypeError('`readFile` and `readPackage` are mutually exclusive.');
+        return process.nextTick(function () {
+            cb(conflictErr);
+        });
+    }
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
@@ -211,9 +232,10 @@ module.exports = function resolve(x, options, callback) {
                 // on err, ex is false
                 if (!ex) return loadpkg(path.dirname(dir), cb);
 
-                readFile(pkgfile, function (err, body) {
+                readPackage(readFile, pkgfile, function (err, pkgParam) {
                     if (err) cb(err);
-                    try { var pkg = JSON.parse(body); } catch (jsonErr) {}
+
+                    var pkg = pkgParam;
 
                     if (pkg && opts.packageFilter) {
                         pkg = opts.packageFilter(pkg, pkgfile, dir);
@@ -239,11 +261,10 @@ module.exports = function resolve(x, options, callback) {
                 if (err) return cb(err);
                 if (!ex) return loadAsFile(path.join(x, 'index'), fpkg, cb);
 
-                readFile(pkgfile, function (err, body) {
+                readPackage(readFile, pkgfile, function (err, pkgParam) {
                     if (err) return cb(err);
-                    try {
-                        var pkg = JSON.parse(body);
-                    } catch (jsonErr) {}
+
+                    var pkg = pkgParam;
 
                     if (pkg && opts.packageFilter) {
                         pkg = opts.packageFilter(pkg, pkgfile, pkgdir);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -45,6 +45,14 @@ var maybeRealpathSync = function maybeRealpathSync(realpathSync, x, opts) {
     return x;
 };
 
+var defaultReadPackageSync = function defaultReadPackageSync(readFileSync, pkgfile) {
+    var body = readFileSync(pkgfile);
+    try {
+        var pkg = JSON.parse(body);
+        return pkg;
+    } catch (jsonErr) {}
+};
+
 var getPackageCandidates = function getPackageCandidates(x, start, opts) {
     var dirs = nodeModulesPaths(start, opts, x);
     for (var i = 0; i < dirs.length; i++) {
@@ -63,6 +71,10 @@ module.exports = function resolveSync(x, options) {
     var isDirectory = opts.isDirectory || defaultIsDir;
     var readFileSync = opts.readFileSync || fs.readFileSync;
     var realpathSync = opts.realpathSync || defaultRealpathSync;
+    var readPackageSync = opts.readPackageSync || defaultReadPackageSync;
+    if (opts.readFileSync && opts.readPackageSync) {
+        throw new TypeError('`readFileSync` and `readPackageSync` are mutually exclusive.');
+    }
     var packageIterator = opts.packageIterator;
 
     var extensions = opts.extensions || ['.js'];
@@ -133,11 +145,7 @@ module.exports = function resolveSync(x, options) {
             return loadpkg(path.dirname(dir));
         }
 
-        var body = readFileSync(pkgfile);
-
-        try {
-            var pkg = JSON.parse(body);
-        } catch (jsonErr) {}
+        var pkg = readPackageSync(readFileSync, pkgfile);
 
         if (pkg && opts.packageFilter) {
             pkg = opts.packageFilter(pkg, pkgfile, dir);
@@ -150,8 +158,7 @@ module.exports = function resolveSync(x, options) {
         var pkgfile = path.join(isDirectory(x) ? maybeRealpathSync(realpathSync, x, opts) : x, '/package.json');
         if (isFile(pkgfile)) {
             try {
-                var body = readFileSync(pkgfile, 'UTF8');
-                var pkg = JSON.parse(body);
+                var pkg = readPackageSync(readFileSync, pkgfile);
             } catch (e) {}
 
             if (pkg && opts.packageFilter) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -71,7 +71,10 @@ options are:
 
 * opts.realpath - function to asynchronously resolve a potential symlink to its real path
 
-* opts.realpath - function to asynchronously resolve a potential symlink to its real path
+* `opts.readPackage(readFile, pkgfile, cb)` - function to asynchronously read and parse a package.json file
+  * readFile - the passed `opts.readFile` or `fs.readFile` if not specified
+  * pkgfile - path to package.json
+  * cb - callback
 
 * `opts.packageFilter(pkg, pkgfile, dir)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
@@ -137,6 +140,19 @@ default `opts` values:
             else cb(null, realPathErr ? file : realPath);
         });
     },
+    readPackage: function defaultReadPackage(readFile, pkgfile, cb) {
+        readFile(pkgfile, function (readFileErr, body) {
+            if (readFileErr) cb(readFileErr);
+            else {
+                try {
+                    var pkg = JSON.parse(body);
+                    cb(null, pkg);
+                } catch (jsonErr) {
+                    cb(null);
+                }
+            }
+        });
+    },
     moduleDirectory: 'node_modules',
     preserveSymlinks: false
 }
@@ -155,13 +171,17 @@ options are:
 
 * opts.includeCoreModules - set to `false` to exclude node core modules (e.g. `fs`) from the search
 
-* opts.readFile - how to read files synchronously
+* opts.readFileSync - how to read files synchronously
 
 * opts.isFile - function to synchronously test whether a file exists
 
 * opts.isDirectory - function to synchronously test whether a file exists and is a directory
 
 * opts.realpathSync - function to synchronously resolve a potential symlink to its real path
+
+* `opts.readPackageSync(readFileSync, pkgfile)` - function to synchronously read and parse a package.json file
+  * readFileSync - the passed `opts.readFileSync` or `fs.readFileSync` if not specified
+  * pkgfile - path to package.json
 
 * `opts.packageFilter(pkg, pkgfile, dir)` - transform the parsed package.json contents before looking at the "main" field
   * pkg - package data
@@ -230,6 +250,13 @@ default `opts` values:
             }
         }
         return file;
+    },
+    readPackageSync: function defaultReadPackageSync(readFileSync, pkgfile) {
+        var body = readFileSync(pkgfile);
+        try {
+            var pkg = JSON.parse(body);
+            return pkg;
+        } catch (jsonErr) {}
     },
     moduleDirectory: 'node_modules',
     preserveSymlinks: false

--- a/test/mock_sync.js
+++ b/test/mock_sync.js
@@ -140,3 +140,78 @@ test('symlinked', function (t) {
         path.resolve('/foo/bar/symlinked/baz.js')
     );
 });
+
+test('readPackageSync', function (t) {
+    t.plan(3);
+
+    var files = {};
+    files[path.resolve('/foo/node_modules/bar/something-else.js')] = 'beep';
+    files[path.resolve('/foo/node_modules/bar/package.json')] = JSON.stringify({
+        main: './baz.js'
+    });
+    files[path.resolve('/foo/node_modules/bar/baz.js')] = 'boop';
+
+    var dirs = {};
+    dirs[path.resolve('/foo')] = true;
+    dirs[path.resolve('/foo/node_modules')] = true;
+
+    function opts(basedir, useReadPackage) {
+        return {
+            basedir: path.resolve(basedir),
+            isFile: function (file) {
+                return Object.prototype.hasOwnProperty.call(files, path.resolve(file));
+            },
+            isDirectory: function (dir) {
+                return !!dirs[path.resolve(dir)];
+            },
+            readFileSync: useReadPackage ? null : function (file) {
+                return files[path.resolve(file)];
+            },
+            realpathSync: function (file) {
+                return file;
+            }
+        };
+    }
+    t.test('with readFile', function (st) {
+        st.plan(1);
+
+        st.equal(
+            resolve.sync('bar', opts('/foo')),
+            path.resolve('/foo/node_modules/bar/baz.js')
+        );
+    });
+
+    var readPackageSync = function (readFileSync, file) {
+        if (file.indexOf(path.join('bar', 'package.json')) >= 0) {
+            return { main: './something-else.js' };
+        } else {
+            return JSON.parse(files[path.resolve(file)]);
+        }
+    };
+
+    t.test('with readPackage', function (st) {
+        st.plan(1);
+
+        var options = opts('/foo');
+        delete options.readFileSync;
+        options.readPackageSync = readPackageSync;
+
+        st.equal(
+            resolve.sync('bar', options),
+            path.resolve('/foo/node_modules/bar/something-else.js')
+        );
+    });
+
+    t.test('with readFile and readPackage', function (st) {
+        st.plan(1);
+
+        var options = opts('/foo');
+        options.readPackageSync = readPackageSync;
+        st.throws(
+            function () { resolve.sync('bar', options); },
+            TypeError,
+            'errors when both readFile and readPackage are provided'
+        );
+    });
+});
+


### PR DESCRIPTION
From discussion in https://github.com/facebook/jest/issues/11034

While `readFile` and `readFileSync` allows consumers to cache the FS operation, `resolve` will always do `JSON.parse` on the file content. `readPkg` and `readPkgSync` allows users to also cache that, if they want, avoiding the extra and potentially redundant JSON parsing.

This change largely makes `readFile` and `readFileSync` redundant IMO (as the only time `resolve` actually reads files is to read and parse `package.json` files), so for v2 it's a possibility to remove them.