### PR TITLE
More detailed not_found error

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -105,7 +105,7 @@ module.exports = function resolveSync(x, options) {
         if (n) return maybeRealpathSync(realpathSync, n, opts);
     }
 
-    var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
+    var err = new Error("Cannot find module '" + x + "' from '" + parent + "'. Please verify that module installed, the package.json has 'main' field or module has index.js file");
     err.code = 'MODULE_NOT_FOUND';
     throw err;
 

--- a/test/resolver_sync.js
+++ b/test/resolver_sync.js
@@ -31,7 +31,7 @@ test('foo', function (t) {
         },
         {
             name: 'Error',
-            message: "Cannot find module 'foo' from '" + path.join(dir, 'bar.js') + "'"
+            message: "Cannot find module 'foo' from '" + path.join(dir, 'bar.js') + "'. Please verify that module installed, the package.json has 'main' field or module has index.js file"
         }
     );
 
@@ -275,7 +275,7 @@ test('sync: #121 - treating an existing file as a dir when no basedir', function
             st.equal(e.code, 'MODULE_NOT_FOUND', 'error code matches require.resolve');
             st.equal(
                 e.message,
-                'Cannot find module \'./' + testFile + '/blah\' from \'' + __dirname + '\'',
+                'Cannot find module \'./' + testFile + '/blah\' from \'' + __dirname + '\'. Please verify that module installed, the package.json has \'main\' field or module has index.js file',
                 'can not find nonexistent module'
             );
         }


### PR DESCRIPTION
Hello!
I added more detailed error in case of MODULE_NOT_FOUND.
Recently I had a problem with jest, which uses this package for searching dependencies. And there was this error. But I had module installed, I seen it with my eyes and could navigate to it via IDE. I spent several hours debugging the reason why it cannot be found. The reason was that module has no index.js file and `main` field in package.json, so I just added alias. I believe that more detailed error text could help me.