### PR TITLE
Add test malformed_package_json directory to npm ignore to avoid problems with FlowJS

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,4 +10,7 @@ yarn.lock
 # symlinked file used in tests
 test/resolver/symlinked/_/node_modules/package
 
+# ignore malformed package json
+test/resolver/malformed_package_json
+
 .github/workflows


### PR DESCRIPTION
Better solution ignore whole test directory: https://github.com/browserify/resolve/pull/269

Flow JS is since the latest release failing in our cases with:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/resolve/test/resolver/malformed_package_json/package.json:2:1

Unexpected end of input, expected the token }
```

See also: https://github.com/sulu/sulu/runs/4761348253?check_suite_focus=true

I think the whole `test` directory is not required to be in the publish packages and so it will reduce also the download size of this package.