### PR TITLE
[New] add default support for `paths` to include `$HOME/.node_{modules,libraries}`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
         "func-style": 0,
         "global-require": 1,
         "id-length": [2, { "min": 1, "max": 30 }],
+        "max-lines": [2, 350],
         "max-lines-per-function": 1,
         "max-nested-callbacks": 0,
         "max-params": 0,

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var getHomedir = require('./homedir');
 var path = require('path');
 var caller = require('./caller');
 var nodeModulesPaths = require('./node-modules-paths');
@@ -6,6 +7,14 @@ var normalizeOptions = require('./normalize-options');
 var isCore = require('is-core-module');
 
 var realpathFS = fs.realpath && typeof fs.realpath.native === 'function' ? fs.realpath.native : fs.realpath;
+
+var homedir = getHomedir();
+var defaultPaths = function () {
+    return [
+        path.join(homedir, '.node_modules'),
+        path.join(homedir, '.node_libraries')
+    ];
+};
 
 var defaultIsFile = function isFile(file, cb) {
     fs.stat(file, function (err, stat) {
@@ -98,7 +107,7 @@ module.exports = function resolve(x, options, callback) {
     var basedir = opts.basedir || path.dirname(caller());
     var parent = opts.filename || basedir;
 
-    opts.paths = opts.paths || [];
+    opts.paths = opts.paths || defaultPaths();
 
     // ensure that `basedir` is an absolute path at this point, resolving against the process' current working directory
     var absoluteStart = path.resolve(basedir);

--- a/lib/homedir.js
+++ b/lib/homedir.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var os = require('os');
+
+// adapted from https://github.com/sindresorhus/os-homedir/blob/11e089f4754db38bb535e5a8416320c4446e8cfd/index.js
+
+module.exports = os.homedir || function homedir() {
+    var home = process.env.HOME;
+    var user = process.env.LOGNAME || process.env.USER || process.env.LNAME || process.env.USERNAME;
+
+    if (process.platform === 'win32') {
+        return process.env.USERPROFILE || process.env.HOMEDRIVE + process.env.HOMEPATH || home || null;
+    }
+
+    if (process.platform === 'darwin') {
+        return home || (user ? '/Users/' + user : null);
+    }
+
+    if (process.platform === 'linux') {
+        return home || (process.getuid() === 0 ? '/root' : (user ? '/home/' + user : null)); // eslint-disable-line no-extra-parens
+    }
+
+    return home || null;
+};

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,11 +1,20 @@
 var isCore = require('is-core-module');
 var fs = require('fs');
 var path = require('path');
+var getHomedir = require('./homedir');
 var caller = require('./caller');
 var nodeModulesPaths = require('./node-modules-paths');
 var normalizeOptions = require('./normalize-options');
 
 var realpathFS = fs.realpathSync && typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
+
+var homedir = getHomedir();
+var defaultPaths = function () {
+    return [
+        path.join(homedir, '.node_modules'),
+        path.join(homedir, '.node_libraries')
+    ];
+};
 
 var defaultIsFile = function isFile(file) {
     try {
@@ -78,7 +87,7 @@ module.exports = function resolveSync(x, options) {
     var basedir = opts.basedir || path.dirname(caller());
     var parent = opts.filename || basedir;
 
-    opts.paths = opts.paths || [];
+    opts.paths = opts.paths || defaultPaths();
 
     // ensure that `basedir` is an absolute path at this point, resolving against the process' current working directory
     var absoluteStart = maybeRealpathSync(realpathSync, path.resolve(basedir), opts);

--- a/package.json
+++ b/package.json
@@ -44,13 +44,18 @@
 		"@ljharb/eslint-config": "^20.2.0",
 		"array.prototype.map": "^1.0.4",
 		"aud": "^2.0.0",
+		"copy-dir": "^1.3.0",
 		"eclint": "^2.8.1",
 		"eslint": "^8.7.0",
 		"in-publish": "^2.0.1",
+		"mkdirp": "^0.5.5",
+		"mv": "^2.1.1",
 		"object-keys": "^1.1.1",
+		"rimraf": "^2.7.1",
 		"safe-publish-latest": "^2.0.0",
 		"tap": "0.4.13",
-		"tape": "^5.4.1"
+		"tape": "^5.4.1",
+		"tmp": "^0.0.31"
 	},
 	"license": "MIT",
 	"author": {

--- a/test/home_paths.js
+++ b/test/home_paths.js
@@ -1,0 +1,127 @@
+'use strict';
+
+var fs = require('fs');
+var homedir = require('../lib/homedir');
+var path = require('path');
+
+var test = require('tape');
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var mv = require('mv');
+var copyDir = require('copy-dir');
+var tmp = require('tmp');
+
+var HOME = homedir();
+
+var hnm = path.join(HOME, '.node_modules');
+var hnl = path.join(HOME, '.node_libraries');
+
+var resolve = require('../async');
+
+function makeDir(t, dir, cb) {
+    mkdirp(dir, function (err) {
+        if (err) {
+            cb(err);
+        } else {
+            t.teardown(function cleanup() {
+                rimraf.sync(dir);
+            });
+            cb();
+        }
+    });
+}
+
+function makeTempDir(t, dir, cb) {
+    if (fs.existsSync(dir)) {
+        var tmpResult = tmp.dirSync();
+        t.teardown(tmpResult.removeCallback);
+        var backup = path.join(tmpResult.name, path.basename(dir));
+        mv(dir, backup, function (err) {
+            if (err) {
+                cb(err);
+            } else {
+                t.teardown(function () {
+                    mv(backup, dir, cb);
+                });
+                makeDir(t, dir, cb);
+            }
+        });
+    } else {
+        makeDir(t, dir, cb);
+    }
+}
+
+test('homedir module paths', function (t) {
+    t.plan(7);
+
+    makeTempDir(t, hnm, function (err) {
+        t.error(err, 'no error with HNM temp dir');
+        if (err) {
+            return t.end();
+        }
+
+        var bazHNMDir = path.join(hnm, 'baz');
+        var dotMainDir = path.join(hnm, 'dot_main');
+        copyDir.sync(path.join(__dirname, 'resolver/baz'), bazHNMDir);
+        copyDir.sync(path.join(__dirname, 'resolver/dot_main'), dotMainDir);
+
+        var bazPkg = { name: 'baz', main: 'quux.js' };
+        var dotMainPkg = { main: 'index' };
+
+        var bazHNMmain = path.join(bazHNMDir, 'quux.js');
+        t.equal(require.resolve('baz'), bazHNMmain, 'sanity check: require.resolve finds HNM `baz`');
+        var dotMainMain = path.join(dotMainDir, 'index.js');
+        t.equal(require.resolve('dot_main'), dotMainMain, 'sanity check: require.resolve finds `dot_main`');
+
+        makeTempDir(t, hnl, function (err) {
+            t.error(err, 'no error with HNL temp dir');
+            if (err) {
+                return t.end();
+            }
+            var bazHNLDir = path.join(hnl, 'baz');
+            copyDir.sync(path.join(__dirname, 'resolver/baz'), bazHNLDir);
+
+            var dotSlashMainDir = path.join(hnl, 'dot_slash_main');
+            var dotSlashMainMain = path.join(dotSlashMainDir, 'index.js');
+            var dotSlashMainPkg = { main: 'index' };
+            copyDir.sync(path.join(__dirname, 'resolver/dot_slash_main'), dotSlashMainDir);
+
+            t.equal(require.resolve('baz'), bazHNMmain, 'sanity check: require.resolve finds HNM `baz`');
+            t.equal(require.resolve('dot_slash_main'), dotSlashMainMain, 'sanity check: require.resolve finds HNL `dot_slash_main`');
+
+            t.test('with temp dirs', function (st) {
+                st.plan(3);
+
+                st.test('just in `$HOME/.node_modules`', function (s2t) {
+                    s2t.plan(3);
+
+                    resolve('dot_main', function (err, res, pkg) {
+                        s2t.error(err, 'no error resolving `dot_main`');
+                        s2t.equal(res, dotMainMain, '`dot_main` resolves in `$HOME/.node_modules`');
+                        s2t.deepEqual(pkg, dotMainPkg);
+                    });
+                });
+
+                st.test('just in `$HOME/.node_libraries`', function (s2t) {
+                    s2t.plan(3);
+
+                    resolve('dot_slash_main', function (err, res, pkg) {
+                        s2t.error(err, 'no error resolving `dot_slash_main`');
+                        s2t.equal(res, dotSlashMainMain, '`dot_slash_main` resolves in `$HOME/.node_libraries`');
+                        s2t.deepEqual(pkg, dotSlashMainPkg);
+                    });
+                });
+
+                st.test('in `$HOME/.node_libraries` and `$HOME/.node_modules`', function (s2t) {
+                    s2t.plan(3);
+
+                    resolve('baz', function (err, res, pkg) {
+                        s2t.error(err, 'no error resolving `baz`');
+                        s2t.equal(res, bazHNMmain, '`baz` resolves in `$HOME/.node_modules` when in both');
+                        s2t.deepEqual(pkg, bazPkg);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/home_paths_sync.js
+++ b/test/home_paths_sync.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var fs = require('fs');
+var homedir = require('../lib/homedir');
+var path = require('path');
+
+var test = require('tape');
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var mv = require('mv');
+var copyDir = require('copy-dir');
+var tmp = require('tmp');
+
+var HOME = homedir();
+
+var hnm = path.join(HOME, '.node_modules');
+var hnl = path.join(HOME, '.node_libraries');
+
+var resolve = require('../sync');
+
+function makeDir(t, dir, cb) {
+    mkdirp(dir, function (err) {
+        if (err) {
+            cb(err);
+        } else {
+            t.teardown(function cleanup() {
+                rimraf.sync(dir);
+            });
+            cb();
+        }
+    });
+}
+
+function makeTempDir(t, dir, cb) {
+    if (fs.existsSync(dir)) {
+        var tmpResult = tmp.dirSync();
+        t.teardown(tmpResult.removeCallback);
+        var backup = path.join(tmpResult.name, path.basename(dir));
+        mv(dir, backup, function (err) {
+            if (err) {
+                cb(err);
+            } else {
+                t.teardown(function () {
+                    mv(backup, dir, cb);
+                });
+                makeDir(t, dir, cb);
+            }
+        });
+    } else {
+        makeDir(t, dir, cb);
+    }
+}
+
+test('homedir module paths', function (t) {
+    t.plan(7);
+
+    makeTempDir(t, hnm, function (err) {
+        t.error(err, 'no error with HNM temp dir');
+        if (err) {
+            return t.end();
+        }
+
+        var bazHNMDir = path.join(hnm, 'baz');
+        var dotMainDir = path.join(hnm, 'dot_main');
+        copyDir.sync(path.join(__dirname, 'resolver/baz'), bazHNMDir);
+        copyDir.sync(path.join(__dirname, 'resolver/dot_main'), dotMainDir);
+
+        var bazHNMmain = path.join(bazHNMDir, 'quux.js');
+        t.equal(require.resolve('baz'), bazHNMmain, 'sanity check: require.resolve finds HNM `baz`');
+        var dotMainMain = path.join(dotMainDir, 'index.js');
+        t.equal(require.resolve('dot_main'), dotMainMain, 'sanity check: require.resolve finds `dot_main`');
+
+        makeTempDir(t, hnl, function (err) {
+            t.error(err, 'no error with HNL temp dir');
+            if (err) {
+                return t.end();
+            }
+            var bazHNLDir = path.join(hnl, 'baz');
+            copyDir.sync(path.join(__dirname, 'resolver/baz'), bazHNLDir);
+
+            var dotSlashMainDir = path.join(hnl, 'dot_slash_main');
+            var dotSlashMainMain = path.join(dotSlashMainDir, 'index.js');
+            copyDir.sync(path.join(__dirname, 'resolver/dot_slash_main'), dotSlashMainDir);
+
+            t.equal(require.resolve('baz'), bazHNMmain, 'sanity check: require.resolve finds HNM `baz`');
+            t.equal(require.resolve('dot_slash_main'), dotSlashMainMain, 'sanity check: require.resolve finds HNL `dot_slash_main`');
+
+            t.test('with temp dirs', function (st) {
+                st.plan(3);
+
+                st.test('just in `$HOME/.node_modules`', function (s2t) {
+                    s2t.plan(1);
+
+                    var res = resolve('dot_main');
+                    s2t.equal(res, dotMainMain, '`dot_main` resolves in `$HOME/.node_modules`');
+                });
+
+                st.test('just in `$HOME/.node_libraries`', function (s2t) {
+                    s2t.plan(1);
+
+                    var res = resolve('dot_slash_main');
+                    s2t.equal(res, dotSlashMainMain, '`dot_slash_main` resolves in `$HOME/.node_libraries`');
+                });
+
+                st.test('in `$HOME/.node_libraries` and `$HOME/.node_modules`', function (s2t) {
+                    s2t.plan(1);
+
+                    var res = resolve('baz');
+                    s2t.equal(res, bazHNMmain, '`baz` resolves in `$HOME/.node_modules` when in both');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Note, this is a rarely used feature that should be aggressively avoided, but it‘s important to minimize gaps between node and this package.

Fixes #163.

I'm uncertain if I'll backport this to the 1.x branch, primarily because of the risk of unintentional breakage. However, since virtually nobody is going to be using these directories, and since it's only going to potentially _start_ resolving bare specifiers where previously there was an error, this does seem safe.