### PR TITLE
chore: remove tests from package build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,6 @@ test/resolver/symlinked/_/node_modules/package
 
 .github/workflows
 appveyor.yml
+
+# tests
+test/**


### PR DESCRIPTION
Hi,
we have problem with out vulnerability management which scans package.json files and try to find vulnerabilities. We use PRISMA from Palo Alto. Problem is that you are trying to test validity of package.json file in test which is not well formatted package.json file. Our vulnerability management has problem with this invalid package.json. I think it is better not to include tests to build of npm package.

Thanks 
Jan