### PR TITLE
do not bundle `tests` directory in npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,8 +7,7 @@ npm-shrinkwrap.json
 package-lock.json
 yarn.lock
 
-# symlinked file used in tests
-test/resolver/symlinked/_/node_modules/package
+test/
 
 .github/workflows
 appveyor.yml


### PR DESCRIPTION
Reduces size of the bundle and prevents https://github.com/meteor/meteor/issues/11839 from happening.

Happy to get your thoughts on this @ljharb 