### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+appveyor.yml
+.editorconfig
+.eslintrc
+example/
+.github/
+test/


### PR DESCRIPTION
The current contents of the `resolve` package on npm are:

```
.
├── appveyor.yml
├── async.js
├── bin
├── .editorconfig
├── .eslintrc
├── example
├── .github
├── index.js
├── lib
├── LICENSE
├── package.json
├── readme.markdown
├── SECURITY.md
├── sync.js
└── test
```

After applying this `.npmignore` the contents will be:

```
.
├── async.js
├── bin
├── index.js
├── lib
├── LICENSE
├── package.json
├── readme.markdown
├── SECURITY.md
└── sync.js
```

Closes #271