### PR TITLE
[meta] Exclude tests and config files from publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,11 @@
 	"publishConfig": {
 		"ignore": [
 			".github/workflows",
-			"appveyor.yml"
+			"appveyor.yml",
+			"test",
+			".editorconfig",
+			".eslintrc",
+			"example"
 		]
 	}
 }


### PR DESCRIPTION
Tests and config files don't need to be in the published package (the `test` folder alone is over half the size of the total package!). We might want to keep the `example` folder though, so I can change that if we want to keep it in the release.