### PR TITLE
Fix invalid values in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,10 +25,10 @@ indent_style = space
 indent_size = 2
 
 [{*.json,Makefile}]
-max_line_length = off
+max_line_length = unset
 
 [test/{dotdot,resolver,module_dir,multirepo,node_path,pathfilter,precedence}/**/*]
-indent_style = off
-indent_size = off
-max_line_length = off
-insert_final_newline = off
+indent_style = unset
+indent_size = unset
+max_line_length = unset
+insert_final_newline = unset


### PR DESCRIPTION
According to [editorconfig docs](https://editorconfig.org/#supported-properties) `off` is not a valid value, but `unset` should be used.

Fixes #272 