### PR TITLE
Treat missing "main" as index.js

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -280,13 +280,12 @@ module.exports = function resolve(x, options, callback) {
                     }
 
                     if (pkg && pkg.main) {
-                        if (typeof pkg.main !== 'string') {
-                            var mainError = new TypeError('package “' + pkg.name + '” `main` must be a string');
-                            mainError.code = 'INVALID_PACKAGE_MAIN';
-                            return cb(mainError);
-                        }
-                        if (pkg.main === '.' || pkg.main === './') {
-                            pkg.main = 'index';
+                        if (pkg.main === "." || pkg.main === "./" || typeof pkg.main === undefined) {
+                          pkg.main = "index";
+                        } else if (typeof pkg.main !== "string") {
+                          var mainError = new TypeError("package “" + pkg.name + "” `main` must be a string");
+                          mainError.code = "INVALID_PACKAGE_MAIN";
+                          return cb(mainError);
                         }
                         loadAsFile(path.resolve(x, pkg.main), pkg, function (err, m, pkg) {
                             if (err) return cb(err);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -177,14 +177,14 @@ module.exports = function resolveSync(x, options) {
                 pkg = opts.packageFilter(pkg, pkgfile, x);
             }
 
-            if (pkg && pkg.main) {
-                if (typeof pkg.main !== 'string') {
+            if (pkg) {
+                if (pkg.main === '.' || pkg.main === './' || typeof pkg.main === 'undefined') {
+                    pkg.main = 'index';
+                }
+                else if (typeof pkg.main !== 'string') {
                     var mainError = new TypeError('package “' + pkg.name + '” `main` must be a string');
                     mainError.code = 'INVALID_PACKAGE_MAIN';
                     throw mainError;
-                }
-                if (pkg.main === '.' || pkg.main === './') {
-                    pkg.main = 'index';
                 }
                 try {
                     var mainPath = path.resolve(x, pkg.main);


### PR DESCRIPTION
As per https://docs.npmjs.com/cli/v9/configuring-npm/package-json#main:

> If `main` is not set it defaults to `index.js` in the package's root folder.