### PR TITLE
Remove tests from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
 	"publishConfig": {
 		"ignore": [
 			".github/workflows",
-			"appveyor.yml"
+			"appveyor.yml",
+			"test"
 		]
 	}
 }


### PR DESCRIPTION
Reduce package by removing tests from the published package (about 312kb from 424kb).