### PR TITLE
change package name on test to avoid scanning issue

### DIFF
--- a/test/resolver/multirepo/package.json
+++ b/test/resolver/multirepo/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "test-monorepo-symlink",
   "private": true,
   "version": "0.0.0",
   "description": "",

--- a/test/resolver/multirepo/package.json
+++ b/test/resolver/multirepo/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "monorepo-symlink-test",
   "private": true,
   "version": "0.0.0",
   "description": "",


### PR DESCRIPTION
There is a coincidence where a private test package with name `monorepo-symlink-test`

This ends up being mixed by security scanners scanners with https://security.snyk.io/vuln/SNYK-JS-MONOREPOSYMLINKTEST-5865510

This should fix https://github.com/browserify/resolve/issues/312