### PR TITLE
add support for package.json exports

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -309,6 +309,12 @@ module.exports = function resolve(x, options, callback) {
                         return;
                     }
 
+                    if (pkg && pkg.exports) {
+                        var res = resolveExports(pkg.exports, ['require', 'node'], '.');
+                        var exportPath = path.resolve(x, res);
+                        return loadAsFile(exportPath, pkg, cb);
+                    }
+
                     loadAsFile(path.join(x, '/index'), pkg, cb);
                 });
             });

--- a/lib/resolve-exports.js
+++ b/lib/resolve-exports.js
@@ -1,0 +1,40 @@
+// Just walks the exports object synchronously looking for a match.
+// Does not validate that the module it finds actually exists.
+
+// Returns undefined if no match was found, null if a match was explicitly
+// forbidden by setting the value to null in the exports object. Either
+// null or undefined at the caller value have the same effective meaning,
+// no match is available.
+var resolveExports = function resolveExports (exp, conditions, sub) {
+    if (!exp) return exp;
+    if (typeof exp === 'string' && (sub === '.' || sub === null)) return exp;
+    // TODO: check if this should throw?
+    if (typeof exp !== 'object') return null;
+    if (Array.isArray(exp) && (sub === '.' || sub === null)) {
+        for (var i = 0; i < exp.length; i++) {
+            var resolved = resolveExports(exp[i], conditions);
+            if (resolved || resolved === null) return resolved;
+        }
+    }
+    if (sub !== null) {
+        if (Object.prototype.hasOwnProperty.call(exp, sub)) {
+            return resolveExports(exp[sub], conditions, null);
+        } else if (sub !== '.') {
+            // sub=./x, exports={require:'./y'}, not a match
+            return undefined;
+        }
+    }
+    var keys = Object.keys(exp);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (key === 'default') return resolveExports(exp[key], conditions, null);
+        var k = conditions.indexOf(key);
+        if (k !== -1) {
+            const resolved = resolveExports(exp[key], conditions, null);
+            if (resolved || resolved === null) return resolved;
+        }
+    }
+    return undefined;
+}
+
+module.exports = resolveExports;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -5,6 +5,7 @@ var getHomedir = require('./homedir');
 var caller = require('./caller');
 var nodeModulesPaths = require('./node-modules-paths');
 var normalizeOptions = require('./normalize-options');
+var resolveExports = require('./resolve-exports');
 
 var realpathFS = process.platform !== 'win32' && fs.realpathSync && typeof fs.realpathSync.native === 'function' ? fs.realpathSync.native : fs.realpathSync;
 
@@ -198,6 +199,12 @@ module.exports = function resolveSync(x, options) {
                 var incorrectMainError = new Error("Cannot find module '" + path.resolve(x, pkg.main) + "'. Please verify that the package.json has a valid \"main\" entry");
                 incorrectMainError.code = 'INCORRECT_PACKAGE_MAIN';
                 throw incorrectMainError;
+            }
+
+            if (pkg && pkg.exports) {
+                var res = resolveExports(pkg.exports, ['require', 'node'], '.');
+                var exportPath = path.resolve(x, res);
+                return loadAsFileSync(exportPath);
             }
         }
 


### PR DESCRIPTION
Work in progress, but a spike to start going in that direction.

TODO:

- [ ] there's a bunch of lint failures, but most of them look like they're not coming from the new code
- [ ] needs tests
- [ ] pretty sure it's not matching the error wording that node uses, it seems like some care has been taken to match, so it'd be good if this did as well, I'm guessing?