### PR TITLE
[meta] ship only production files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
 		"resolve": "./bin/resolve"
 	},
 	"main": "index.js",
+	"files": [
+		"lib",
+		"bin"
+	],
 	"exports": {
 		".": [
 			{


### PR DESCRIPTION
this will give you ~90% reduction of your  on-disk node_modules footprint (from 644K to 65K), and your package size from 35K to 9.3K.

Good work with the test, bud, but don't ship them...

Here's your current status:
```
 $ du -h node_modules/resolve
4.0K    node_modules/resolve/test/pathfilter/deep_ref
8.0K    node_modules/resolve/test/pathfilter
8.0K    node_modules/resolve/test/dotdot/abc
16.0K   node_modules/resolve/test/dotdot
12.0K   node_modules/resolve/test/precedence/aaa
8.0K    node_modules/resolve/test/precedence/bbb
32.0K   node_modules/resolve/test/precedence
12.0K   node_modules/resolve/test/resolver/baz
16.0K   node_modules/resolve/test/resolver/nested_symlinks/mylib
20.0K   node_modules/resolve/test/resolver/nested_symlinks
8.0K    node_modules/resolve/test/resolver/multirepo/packages/package-b
12.0K   node_modules/resolve/test/resolver/multirepo/packages/package-a
24.0K   node_modules/resolve/test/resolver/multirepo/packages
36.0K   node_modules/resolve/test/resolver/multirepo
12.0K   node_modules/resolve/test/resolver/dot_main
8.0K    node_modules/resolve/test/resolver/without_basedir
12.0K   node_modules/resolve/test/resolver/symlinked/package
4.0K    node_modules/resolve/test/resolver/symlinked/_/symlink_target
4.0K    node_modules/resolve/test/resolver/symlinked/_/node_modules
12.0K   node_modules/resolve/test/resolver/symlinked/_
28.0K   node_modules/resolve/test/resolver/symlinked
12.0K   node_modules/resolve/test/resolver/incorrect_main
8.0K    node_modules/resolve/test/resolver/false_main
8.0K    node_modules/resolve/test/resolver/browser_field
4.0K    node_modules/resolve/test/resolver/other_path/lib
8.0K    node_modules/resolve/test/resolver/other_path
8.0K    node_modules/resolve/test/resolver/same_names/foo
16.0K   node_modules/resolve/test/resolver/same_names
8.0K    node_modules/resolve/test/resolver/invalid_main
8.0K    node_modules/resolve/test/resolver/quux/foo
12.0K   node_modules/resolve/test/resolver/quux
12.0K   node_modules/resolve/test/resolver/dot_slash_main
212.0K  node_modules/resolve/test/resolver
8.0K    node_modules/resolve/test/module_dir/ymodules/aaa
12.0K   node_modules/resolve/test/module_dir/ymodules
12.0K   node_modules/resolve/test/module_dir/zmodules/bbb
16.0K   node_modules/resolve/test/module_dir/zmodules
8.0K    node_modules/resolve/test/module_dir/xmodules/aaa
12.0K   node_modules/resolve/test/module_dir/xmodules
44.0K   node_modules/resolve/test/module_dir
4.0K    node_modules/resolve/test/shadowed_core/node_modules/util
8.0K    node_modules/resolve/test/shadowed_core/node_modules
12.0K   node_modules/resolve/test/shadowed_core
8.0K    node_modules/resolve/test/node_path/x/ccc
8.0K    node_modules/resolve/test/node_path/x/aaa
20.0K   node_modules/resolve/test/node_path/x
8.0K    node_modules/resolve/test/node_path/y/ccc
8.0K    node_modules/resolve/test/node_path/y/bbb
20.0K   node_modules/resolve/test/node_path/y
44.0K   node_modules/resolve/test/node_path
512.0K  node_modules/resolve/test
8.0K    node_modules/resolve/.github
56.0K   node_modules/resolve/lib
8.0K    node_modules/resolve/bin
12.0K   node_modules/resolve/example
644.0K  node_modules/resolve
```

if you ship only `index.js`, `lib` and `bin`....

here's the impact on the package size:
```
$ ls -lah *.tgz
-rw-r--r-- 1 osher osher  25K May  5 20:05 resolve-2.0.0-next.5.before.tgz
-rw-r--r-- 1 osher osher 9.3K May  5 20:07 resolve-2.0.0-next.5.tgz
```
