### PR TITLE
[Chore] Cleanup npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,11 @@
 	},
 	"engines": {
 		"node": ">= 0.4"
-	}
+	},
+	"files": [
+		"*.js",
+		"*.mjs",
+		"lib/",
+		"SECURITY.md"
+	]
 }


### PR DESCRIPTION
chore: remove unnecessary files from the npm package

This PR does not contain any change to the logic or the implementation. It is only reducing size of npm package by excluding files that are not necessary for a standard usage of this library.

Before: 25KB gzipped (138 KB and 102 files unpacked)
After: 9KB gzipped (39 KB and 15 files unpacked)

## New tarball contents

```
Tarball Contents
----------------
1.1kB LICENSE
157B SECURITY.md
56B async.js
1.5kB bin/resolve
97B index.js
93B index.mjs
12.6kB lib/async.js
354B lib/caller.js
805B lib/homedir.js
1.3kB lib/node-modules-paths.js
348B lib/normalize-options.js
7.7kB lib/sync.js
2.3kB package.json
11.2kB readme.markdown
55B sync.js
```