### PR TITLE
[meta] exclude .gitmodules from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
 			"appveyor.yml",
 			"CONTRIBUTING.md",
 			"test/resolver/malformed_package_json",
-			"test/list-exports"
+			"test/list-exports",
+			".gitmodules"
 		]
 	},
 	"engines": {


### PR DESCRIPTION
`.gitmodules` was accidentally included in the published tarball in the latest release — it's the git submodule config for `test/list-exports`, which has no meaning outside of a git repo.

This is breaking installation in Claude Code sandboxes, for reasons expounded on in the linked issue.

The actual `test/list-exports` directory is also already excluded after it was [converted to a submodule](https://github.com/browserify/resolve/commit/ab587d73c30c790d2f4bd49e62095416c2bca2ba). That change in itself might be contra the [often cited](https://github.com/browserify/resolve/pull/105#issuecomment-266653976) goal of including the full set of tests in the package tarball for local offline inspection. Given `.gitmodules` is just a GitHub URL though, its removal doesn't seem to make matters much worse on that front.

Given the severity of the breakage, it might be worth re-releasing `2.0.0-next.6` with the file stripped.

Fixes #339.